### PR TITLE
fix Failed to open stream: No such file or directory

### DIFF
--- a/includes/class-instawp-iwpdb.php
+++ b/includes/class-instawp-iwpdb.php
@@ -1,7 +1,7 @@
 <?php
 // phpcs:disable
 
-include_once 'includes/functions-pull-push.php';
+include_once 'functions-pull-push.php';
 
 class IWPDB {
 


### PR DESCRIPTION
'PHP message: PHP Warning:  include_once(includes/functions-pull-push.php): Failed to open stream: No such file or directory in /home/jixixuvesu4929/web/insta-inventory.a.instawpsites.com/public_html/wp-content/plugins/instawp-connect-main/includes/class-instawp-iwpdb.php on line 4; PHP message: PHP Warning:  include_once(): Failed opening 'includes/functions-pull-push.php' for inclusion (include_path='.:/usr/share/php') in /home/jixixuvesu4929/web/insta-inventory.a.instawpsites.com/public_html/wp-content/plugins/instawp-connect-main/includes/class-instawp-iwpdb.php on line 4'

fixed as per discussion with @jaedm97 