### PR TITLE
Fix/86cwje5xy woocommerce order mismatch

### DIFF
--- a/languages/instawp-connect.pot
+++ b/languages/instawp-connect.pot
@@ -5,7 +5,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-10-08 08:04+0000\n"
+"POT-Creation-Date: 2024-10-08 13:03+0000\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_ex:1,2c;_n:1,2;_n_noop:1,2;_nx:1,2,4c;_nx_noop:1,2,3c;_x:1,2c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c\n"
 "X-Poedit-SearchPath-0: .\n"
@@ -35,6 +35,174 @@ msgstr ""
 
 #: admin/class-instawp-admin.php:148, admin/class-instawp-admin.php:149
 msgid "InstaWP"
+msgstr ""
+
+#: includes/activity-log/class-instawp-activity-log-posts.php:79
+msgid "(no title)"
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api-manage.php:380
+msgid "Invalid data. Unknown type."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api-manage.php:388
+msgid "Invalid data. The item does not exist."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api-manage.php:733
+msgid "Setting does not exist."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api-manage.php:716
+msgid "Success!"
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api-manage.php:725
+msgid "You can not enable this setting through API."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api-manage.php:722
+msgid "Setting is already disabled."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api-migration.php:97
+msgid "Migration could not initiate because the allow_url_fopen is set to false."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api-migration.php:115
+msgid "Could not create destination file."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api-migration.php:192
+msgid "Installation failed"
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api-migration.php:213
+msgid "sso_url_class_not_found: This class NewfoldLabs\WP\Module\Migration\Services\MigrationSSO not found."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api-migration.php:208
+msgid "Error getting SSO login url."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api-migration.php:233
+msgid "Post migration cleanup completed."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:132
+msgid "This request is not authorized."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:139
+msgid "Api key is required."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:153
+msgid "No user found with the provided username."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:161
+msgid "This user does not have capability to config the website."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:180
+msgid "Application password does not match."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:202
+msgid "This website is already connected!"
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:216
+msgid "Invalid API domain parameter passed."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:224
+msgid "API Key is not valid."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:231
+msgid "Something went wrong during connecting to InstaWP."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:238
+msgid "Connected."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:259
+msgid "Invalid connect ID"
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:269
+msgid "Site has been marked as staging"
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:291
+msgid "Plugin reset Successful."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:359, includes/functions.php:715
+msgid "No login information found."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:419
+msgid "All Temporary logins are removed."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:480
+msgid "No items found"
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:489
+msgid "Update task create successfully"
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:550
+msgid "Empty bearer token."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:563
+msgid "Empty api key."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:578
+msgid "Invalid bearer token."
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:715
+msgid "Route not allowed"
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:818, includes/class-instawp-setting.php:537, includes/class-instawp-setting.php:543
+msgid "Heartbeat"
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:819, includes/class-instawp-hooks.php:238, includes/class-instawp-setting.php:231, includes/class-instawp-setting.php:575
+msgid "Database Manager"
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:820, includes/class-instawp-setting.php:583
+msgid "Install Plugin / Themes"
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:821, includes/class-instawp-setting.php:591
+msgid "Update Core / Plugin / Themes"
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:822, includes/class-instawp-setting.php:599
+msgid "Activate / Deactivate"
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:823, includes/class-instawp-setting.php:607
+msgid "Config Management"
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:824, includes/class-instawp-setting.php:615
+msgid "Site Inventory"
+msgstr ""
+
+#: includes/apis/class-instawp-rest-api.php:825, includes/class-instawp-setting.php:232, includes/class-instawp-setting.php:623
+msgid "Debug Log"
 msgstr ""
 
 #: includes/class-instawp-ajax.php:110
@@ -141,10 +309,6 @@ msgstr ""
 msgid "Purge All Cache"
 msgstr ""
 
-#: includes/class-instawp-hooks.php:238, includes/class-instawp-setting.php:231, includes/class-instawp-setting.php:575, includes/apis/class-instawp-rest-api.php:819
-msgid "Database Manager"
-msgstr ""
-
 #: includes/class-instawp-hooks.php:250
 msgid "Shortcuts"
 msgstr ""
@@ -231,10 +395,6 @@ msgstr ""
 
 #: includes/class-instawp-setting.php:184, includes/class-instawp-setting.php:190
 msgid "Disabled"
-msgstr ""
-
-#: includes/class-instawp-setting.php:232, includes/class-instawp-setting.php:623, includes/apis/class-instawp-rest-api.php:825
-msgid "Debug Log"
 msgstr ""
 
 #: includes/class-instawp-setting.php:308
@@ -429,10 +589,6 @@ msgstr ""
 msgid "Enabling this option will enable WordPress debug log."
 msgstr ""
 
-#: includes/class-instawp-setting.php:537, includes/class-instawp-setting.php:543, includes/apis/class-instawp-rest-api.php:818
-msgid "Heartbeat"
-msgstr ""
-
 #: includes/class-instawp-setting.php:538
 msgid "Periodically send heartbeat to the InstaWP dashboard."
 msgstr ""
@@ -473,40 +629,20 @@ msgstr ""
 msgid "Enable this option to manage your database directly from the InstaWP Dashboard."
 msgstr ""
 
-#: includes/class-instawp-setting.php:583, includes/apis/class-instawp-rest-api.php:820
-msgid "Install Plugin / Themes"
-msgstr ""
-
 #: includes/class-instawp-setting.php:584
 msgid "Enable this option to install plugins and themes directly from the InstaWP Dashboard."
-msgstr ""
-
-#: includes/class-instawp-setting.php:591, includes/apis/class-instawp-rest-api.php:821
-msgid "Update Core / Plugin / Themes"
 msgstr ""
 
 #: includes/class-instawp-setting.php:592
 msgid "Enable this option to update WordPress core, themes and plugins directly from the InstaWP Dashboard."
 msgstr ""
 
-#: includes/class-instawp-setting.php:599, includes/apis/class-instawp-rest-api.php:822
-msgid "Activate / Deactivate"
-msgstr ""
-
 #: includes/class-instawp-setting.php:600
 msgid "Enable this option to activate or deactivate themes and plugins directly from the InstaWP Dashboard."
 msgstr ""
 
-#: includes/class-instawp-setting.php:607, includes/apis/class-instawp-rest-api.php:823
-msgid "Config Management"
-msgstr ""
-
 #: includes/class-instawp-setting.php:608
 msgid "Enable this option to manage the Wordpress constant values directly from the InstaWP Dashboard."
-msgstr ""
-
-#: includes/class-instawp-setting.php:615, includes/apis/class-instawp-rest-api.php:824
-msgid "Site Inventory"
 msgstr ""
 
 #: includes/class-instawp-setting.php:616
@@ -521,71 +657,71 @@ msgstr ""
 msgid "Invalid Migration ID"
 msgstr ""
 
-#: includes/class-instawp-tools.php:574
+#: includes/class-instawp-tools.php:576
 msgid "API key not found"
 msgstr ""
 
-#: includes/class-instawp-tools.php:795
+#: includes/class-instawp-tools.php:797
 msgid "Root directory for this WordPress installation could not find."
 msgstr ""
 
-#: includes/class-instawp-tools.php:816
+#: includes/class-instawp-tools.php:818
 msgid "Tracking database could not found."
 msgstr ""
 
-#: includes/class-instawp-tools.php:826
+#: includes/class-instawp-tools.php:828
 msgid "API Signature and others data could not set properly"
 msgstr ""
 
-#: includes/class-instawp-tools.php:852
+#: includes/class-instawp-tools.php:854
 msgid "InstaWP could not access or read required files from your WordPress directory due to file permission issue."
 msgstr ""
 
-#: includes/class-instawp-tools.php:854
+#: includes/class-instawp-tools.php:856
 msgid "Learn more."
 msgstr ""
 
-#: includes/class-instawp-tools.php:1023
+#: includes/class-instawp-tools.php:1025
 msgid "Launch %s"
 msgstr ""
 
-#: includes/class-instawp-tools.php:1111
+#: includes/class-instawp-tools.php:1113
 msgid "Please create staging sites first."
 msgstr ""
 
-#: includes/class-instawp-tools.php:1112
+#: includes/class-instawp-tools.php:1114
 msgid "Skip"
 msgstr ""
 
-#: includes/class-instawp-tools.php:1113
+#: includes/class-instawp-tools.php:1115
 msgid "Do you really want to disconnect the plugin? It will completely remove the existing staging sites from the plugin."
 msgstr ""
 
-#: includes/class-instawp-tools.php:1114
+#: includes/class-instawp-tools.php:1116
 msgid "Do you still want to disconnect the plugin?"
 msgstr ""
 
-#: includes/class-instawp-tools.php:1162
+#: includes/class-instawp-tools.php:1164
 msgid "Zip archive is not opening."
 msgstr ""
 
-#: includes/class-instawp-tools.php:1215
+#: includes/class-instawp-tools.php:1217
 msgid "No compression method find."
 msgstr ""
 
-#: includes/class-instawp-tools.php:1259
+#: includes/class-instawp-tools.php:1261
 msgid "Site ID not found in site create response."
 msgstr ""
 
-#: includes/class-instawp-tools.php:1298
+#: includes/class-instawp-tools.php:1300
 msgid "SFTP login failed."
 msgstr ""
 
-#: includes/class-instawp-tools.php:1309
+#: includes/class-instawp-tools.php:1311
 msgid "SFTP upload failed for files."
 msgstr ""
 
-#: includes/class-instawp-tools.php:1317
+#: includes/class-instawp-tools.php:1319
 msgid "SFTP upload failed for database."
 msgstr ""
 
@@ -603,142 +739,6 @@ msgstr ""
 
 #: includes/functions.php:704
 msgid "Login information for the given username"
-msgstr ""
-
-#: includes/functions.php:715, includes/apis/class-instawp-rest-api.php:359
-msgid "No login information found."
-msgstr ""
-
-#: includes/activity-log/class-instawp-activity-log-posts.php:79
-msgid "(no title)"
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api-manage.php:380
-msgid "Invalid data. Unknown type."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api-manage.php:388
-msgid "Invalid data. The item does not exist."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api-manage.php:733
-msgid "Setting does not exist."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api-manage.php:716
-msgid "Success!"
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api-manage.php:725
-msgid "You can not enable this setting through API."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api-manage.php:722
-msgid "Setting is already disabled."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api-migration.php:97
-msgid "Migration could not initiate because the allow_url_fopen is set to false."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api-migration.php:115
-msgid "Could not create destination file."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api-migration.php:192
-msgid "Installation failed"
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api-migration.php:213
-msgid "sso_url_class_not_found: This class NewfoldLabs\WP\Module\Migration\Services\MigrationSSO not found."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api-migration.php:208
-msgid "Error getting SSO login url."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api-migration.php:233
-msgid "Post migration cleanup completed."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:132
-msgid "This request is not authorized."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:139
-msgid "Api key is required."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:153
-msgid "No user found with the provided username."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:161
-msgid "This user does not have capability to config the website."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:180
-msgid "Application password does not match."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:202
-msgid "This website is already connected!"
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:216
-msgid "Invalid API domain parameter passed."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:224
-msgid "API Key is not valid."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:231
-msgid "Something went wrong during connecting to InstaWP."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:238
-msgid "Connected."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:259
-msgid "Invalid connect ID"
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:269
-msgid "Site has been marked as staging"
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:291
-msgid "Plugin reset Successful."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:419
-msgid "All Temporary logins are removed."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:480
-msgid "No items found"
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:489
-msgid "Update task create successfully"
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:550
-msgid "Empty bearer token."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:563
-msgid "Empty api key."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:578
-msgid "Invalid bearer token."
-msgstr ""
-
-#: includes/apis/class-instawp-rest-api.php:715
-msgid "Route not allowed"
 msgstr ""
 
 #: includes/sync/class-instawp-sync-ajax.php:329
@@ -919,30 +919,30 @@ msgstr ""
 msgid "User not found for delete operation."
 msgstr ""
 
-#: includes/sync/class-instawp-sync-wc.php:39
+#: includes/sync/class-instawp-sync-wc.php:47
 msgid "Order created"
 msgstr ""
 
-#: includes/sync/class-instawp-sync-wc.php:53
+#: includes/sync/class-instawp-sync-wc.php:104
 msgid "Order updated"
 msgstr ""
 
-#: includes/sync/class-instawp-sync-wc.php:67, includes/sync/class-instawp-sync-wc.php:81
+#: includes/sync/class-instawp-sync-wc.php:118, includes/sync/class-instawp-sync-wc.php:132
 msgid "Order trashed"
 msgstr ""
 
-#: includes/sync/class-instawp-sync-wc.php:96
+#: includes/sync/class-instawp-sync-wc.php:147
 msgid "Woocommerce attribute added"
 msgstr ""
 
-#: includes/sync/class-instawp-sync-wc.php:114
+#: includes/sync/class-instawp-sync-wc.php:165
 msgid "Woocommerce attribute updated"
 msgstr ""
 
-#: includes/sync/class-instawp-sync-wc.php:130
+#: includes/sync/class-instawp-sync-wc.php:181
 msgid "Woocommerce attribute deleted"
 msgstr ""
 
-#: includes/sync/class-instawp-sync-wc.php:389, includes/sync/class-instawp-sync-wc.php:394
+#: includes/sync/class-instawp-sync-wc.php:440, includes/sync/class-instawp-sync-wc.php:445
 msgid "Order %s"
 msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,14 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
+= 0.1.0.58 - Beta =
+- FIX - Sync WooCommerce meta data
+- FIX - Sync display WooCommerce order ID on the staging site that matches with the production site
+- FIX - Sync WooCommerce order created and modified date
+- FIX - Sync WooCommerce order total
+- FIX - Sync WooCommerce order blank item added on the staging site
+- FIX - Sync WooCommerce order origin
+
 = 0.1.0.57 - 3 October 2024 =
 - FIX - Showing error if wp-config.php is not writable.
 - FIX - Duplicate plugin and theme installation slug in migration settings


### PR DESCRIPTION
- FIX - Sync WooCommerce meta data
- FIX - Sync display WooCommerce order ID on the staging site that matches with the production site
- FIX - Sync WooCommerce order created and modified date
- FIX - Sync WooCommerce order total
- FIX - Sync WooCommerce order blank item added on the staging site
- FIX - Sync WooCommerce order origin

Note: We add the order ID to the meta data on the production site and display that ID in the staging site's WooCommerce dashboard. After synchronization, the meta ID is also synced with the corresponding order on the staging site (though the actual order ID on staging may differ). This ensures that the same order ID is displayed on both the production and staging sites.

If an order is created on the staging site, no meta data is created for that order initially. However, after syncing, the order ID from the production site will be added to the meta data. This meta order ID will be updated and reflected on the staging site during the next synchronization