### PR TITLE
Exclude WP core folders for migration

### DIFF
--- a/includes/class-instawp-tools.php
+++ b/includes/class-instawp-tools.php
@@ -327,7 +327,7 @@ include $file_path;';
 		}
 
 		/**
-		 * Exclude wp-admin and wp-includes foldera, as minor wp version will auto install during 
+		 * Exclude wp-admin and wp-includes folders, as minor wp version will auto install during 
 		 * staging creation.
 		 * @since 0.1.0.58
 		 */

--- a/includes/class-instawp-tools.php
+++ b/includes/class-instawp-tools.php
@@ -326,6 +326,14 @@ include $file_path;';
 			include ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
+		/**
+		 * Exclude wp-admin and wp-includes foldera, as minor wp version will auto install during 
+		 * staging creation.
+		 * @since 0.1.0.58
+		 */
+		$migrate_settings['excluded_paths'][] = 'wp-admin';
+		$migrate_settings['excluded_paths'][] = 'wp-includes';
+
 		// Remove __wp__ folder for WPC file structure
 		if ( is_dir( $wp_root_dir . '/__wp__' ) ) {
 			$migrate_settings['excluded_paths'][] = $wp_root_dir . '/__wp__';

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 - FIX - Sync WooCommerce order total
 - FIX - Sync WooCommerce order blank item added on the staging site
 - FIX - Sync WooCommerce order origin
+- NEW - Exclude WP core folders for migration
 
 = 0.1.0.57 - 3 October 2024 =
 - FIX - Showing error if wp-config.php is not writable.


### PR DESCRIPTION
Exclude wp-admin and wp-includes folders, as minor wp version will auto install from app during staging creation.