### PR TITLE
Fixed: Proper synchronization of post meta data saved via the save_post hook.

### DIFF
--- a/includes/sync/class-instawp-sync-parser.php
+++ b/includes/sync/class-instawp-sync-parser.php
@@ -342,7 +342,8 @@ class InstaWP_Sync_Parser {
 			return $post;
 		}
 
-		$post               = $_post;
+		// Clone of the post object to avoid reference issues
+		$post               = clone $_post;
 		$post_content       = isset( $post->post_content ) ? $post->post_content : '';
 		$post_parent_id     = $post->post_parent;
 		$reference_id       = InstaWP_Sync_Helpers::get_post_reference_id( $post->ID );

--- a/readme.txt
+++ b/readme.txt
@@ -99,15 +99,15 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 == Changelog ==
 
 = 0.1.0.58 - Beta =
-Fixed: Issue with syncing WooCommerce meta data.
-Fixed: WooCommerce order ID now correctly displays on the staging site, matching the production site.
-Fixed: WooCommerce order creation and modification dates now sync properly.
-Fixed: Corrected synchronization of WooCommerce order totals.
-Fixed: Resolved issue where blank items were being added to WooCommerce orders on the staging site.
-Fixed: WooCommerce order origin now syncs correctly.
-New: WordPress core folders are now excluded from the migration process.
-Fixed: Post meta data is now saved correctly when triggered by action hooks.
-Fixed: Proper synchronization of post meta data saved via the save_post hook.
+- Fixed: Issue with syncing WooCommerce meta data.
+- Fixed: WooCommerce order ID now correctly displays on the staging site, matching the production site.
+- Fixed: WooCommerce order creation and modification dates now sync properly.
+- Fixed: Corrected synchronization of WooCommerce order totals.
+- Fixed: Resolved issue where blank items were being added to WooCommerce orders on the staging site.
+- Fixed: WooCommerce order origin now syncs correctly.
+- New: WordPress core folders are now excluded from the migration process.
+- Fixed: Post meta data is now saved correctly when triggered by action hooks.
+- Fixed: Proper synchronization of post meta data saved via the save_post hook.
 
 = 0.1.0.57 - 3 October 2024 =
 - FIX - Showing error if wp-config.php is not writable.

--- a/readme.txt
+++ b/readme.txt
@@ -99,14 +99,15 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 == Changelog ==
 
 = 0.1.0.58 - Beta =
-- FIX - Sync WooCommerce meta data
-- FIX - Sync display WooCommerce order ID on the staging site that matches with the production site
-- FIX - Sync WooCommerce order created and modified date
-- FIX - Sync WooCommerce order total
-- FIX - Sync WooCommerce order blank item added on the staging site
-- FIX - Sync WooCommerce order origin
-- NEW - Exclude WP core folders for migration
-- FIX - Save post meta on action hook
+Fixed: Issue with syncing WooCommerce meta data.
+Fixed: WooCommerce order ID now correctly displays on the staging site, matching the production site.
+Fixed: WooCommerce order creation and modification dates now sync properly.
+Fixed: Corrected synchronization of WooCommerce order totals.
+Fixed: Resolved issue where blank items were being added to WooCommerce orders on the staging site.
+Fixed: WooCommerce order origin now syncs correctly.
+New: WordPress core folders are now excluded from the migration process.
+Fixed: Post meta data is now saved correctly when triggered by action hooks.
+Fixed: Proper synchronization of post meta data saved via the save_post hook.
 
 = 0.1.0.57 - 3 October 2024 =
 - FIX - Showing error if wp-config.php is not writable.

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 - FIX - Sync WooCommerce order blank item added on the staging site
 - FIX - Sync WooCommerce order origin
 - NEW - Exclude WP core folders for migration
+- FIX - Save post meta on action hook
 
 = 0.1.0.57 - 3 October 2024 =
 - FIX - Showing error if wp-config.php is not writable.


### PR DESCRIPTION
Post data is saved on the 'transition_post_status' action hook, which triggers earlier than the 'save_post' hook. Most plugin authors use the 'save_post' hook to add or update post meta.

We are now using the 'save_post' hook, in combination with the 'transition_post_status' hook, to maintain consistency in event handling.

Bug Fix: Global post content encoding issue resolved.