### PR TITLE
Fix: Push migration exclude files check

### DIFF
--- a/dest.php
+++ b/dest.php
@@ -372,7 +372,11 @@ if ( $file_type === 'zip' ) {
 				for ( $i = 0; $i < $zip->numFiles; $i ++ ) {
 					$file_name = $zip->getNameIndex( $i );
 
-					if ( ! array_contains_str( $directory_name . DIRECTORY_SEPARATOR . $file_name, $excluded_paths ) && ! str_contains( $file_name, 'instawp-autologin' ) ) {
+					if ( false !== strpos( $directory_name, DIRECTORY_SEPARATOR . 'wp-content' ) || false !== strpos( $directory_name, DIRECTORY_SEPARATOR . 'wp-includes' ) || false !== strpos( $directory_name, DIRECTORY_SEPARATOR . 'wp-admin' ) ) {
+						if ( ! array_contains_str( $directory_name . DIRECTORY_SEPARATOR . $file_name, $excluded_paths ) && ! str_contains( $file_name, 'instawp-autologin' ) ) {
+							$extracted_files[] = $file_name;
+						}
+					} else if ( ! in_array( $file_name, $excluded_paths ) && ! str_contains( $file_name, 'instawp-autologin' ) ) {
 						//file_put_contents( $root_dir_path . DIRECTORY_SEPARATOR . 'iwp_log.txt', "zip path: " . $directory_name . DIRECTORY_SEPARATOR . $file_name . "\n", FILE_APPEND );
 						$extracted_files[] = $file_name;
 					}

--- a/readme.txt
+++ b/readme.txt
@@ -100,6 +100,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 = 0.1.0.79 - January 2025 =
 - FIX: Fixed cache clearing issue with WP Rocket.
+- Fix: Push migration exclude files check
 
 = 0.1.0.78 - 16 January 2025 =
 - NEW: Added extra log message for handling pull migration failure.


### PR DESCRIPTION
Push migration dest.php contains below code. array_contains_str()   compare  $excluded_paths in all files and folders. e.g. index.html in excluded path is meant for root only but it exclude this file in all folders
if ( ! array_contains_str( $directory_name . DIRECTORY_SEPARATOR . $file_name, $excluded_paths ) && ! str_contains( $file_name, 'instawp-autologin' ) ) {
                        //file_put_contents( $root_dir_path . DIRECTORY_SEPARATOR . 'iwp_log.txt', "zip path: " . $directory_name . DIRECTORY_SEPARATOR . $file_name . "\n", FILE_APPEND );
                        $extracted_files[] = $file_name;
                    }
