### PR TITLE
fix: improve local push error handling and site creation

### DIFF
--- a/includes/class-instawp-cli.php
+++ b/includes/class-instawp-cli.php
@@ -40,7 +40,7 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 			delete_option( 'instawp_parent_is_on_local' );
 
 			// Create Site
-			if ( is_wp_error( $create_site_res = InstaWP_Tools::create_insta_site() ) ) {
+			if ( is_wp_error( $create_site_res = InstaWP_Tools::create_insta_site( true ) ) ) {
 				die( esc_html( $create_site_res->get_error_message() ) );
 			}
 

--- a/includes/class-instawp-tools.php
+++ b/includes/class-instawp-tools.php
@@ -2050,21 +2050,22 @@ include $file_path;';
 		return new WP_Error( 'no_method_find', esc_html__( 'No compression method find.', 'instawp-connect' ) );
 	}
 
-	public static function create_insta_site() {
+	public static function create_insta_site( $is_reserved = false ) {
 		$connect_id = instawp_get_connect_id();
 
 		// Creating new blank site
 		$sites_args        = array(
-			'wp_version'  => '6.3',
-			'php_version' => '7.4',
-			'is_reserved' => false,
+			'wp_version'  => function_exists('get_bloginfo') ? get_bloginfo( 'version' ): '6.9.4',
+			'php_version' => function_exists('phpversion') ? phpversion(): '8.3',
+			'is_reserved' => $is_reserved,
 		);
+
 		$sites_res         = Curl::do_curl( "connects/{$connect_id}/sites/create-staging", $sites_args );
 		$sites_res_status  = (bool) Helper::get_args_option( 'success', $sites_res, true );
-		$sites_res_message = Helper::get_args_option( 'message', $sites_res, true );
+		$sites_res_message = Helper::get_args_option( 'message', $sites_res );
 
 		if ( ! $sites_res_status ) {
-			return new WP_Error( 'could_not_create_site', $sites_res_message );
+			return new WP_Error( 'could_not_create_site', sanitize_text_field( $sites_res_message ) );
 		}
 
 		$sites_res_data = Helper::get_args_option( 'data', $sites_res, array() );
@@ -2085,7 +2086,12 @@ include $file_path;';
 
 				error_log( "local_push_migration_progress: {$percentage_complete}" );
 
-				if ( $restore_status === 'completed' ) {
+				if ( $restore_status === 'error' ) {
+					$comment      = Helper::get_args_option( 'comment', $status_res_data, 'Error: ' . esc_html__( 'Failed to create site with WordPress ', 'instawp-connect' ) . $sites_args['wp_version'] . '& Php ' . $sites_args['php_version'] );
+					$comment = explode('Error:', $comment, 2);
+					return new WP_Error( 'could_not_create_site', sanitize_text_field( isset($comment[1]) ? $comment[1] : $comment[0] ) );
+					break;
+				} else if ( $restore_status === 'completed' ) {
 					break;
 				}
 
@@ -2191,7 +2197,12 @@ include $file_path;';
 
 			error_log( "local_push_migration_progress: {$percentage_complete}" );
 
-			if ( $restore_status === 'completed' ) {
+			if ( $restore_status === 'error' ) {
+				$comment      = Helper::get_args_option( 'comment', $status_res_data, 'Error: ' . esc_html__( 'Failed to restore the created site from the given backup.', 'instawp-connect' ) );
+				$comment = explode('Error:', $comment, 2);
+				return new WP_Error( 'restore_raw_api_failed', sanitize_text_field( isset($comment[1]) ? $comment[1] : $comment[0] ) );
+				break;
+			} else if ( $restore_status === 'completed' ) {
 				break;
 			}
 

--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,12 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
+
+= 0.1.3.1 - Beta =
+- Improved: Local push site creation and restore now handle task errors gracefully.
+- Improved: Local push now uses current site WP and PHP versions for staging site.
+- Improved: Local push now creates a reserved site for better reliability.
+
 = 0.1.3.0 - 31 March 2026 =
 - Fixed: Improved response details
 - Optimized: Plugin and theme updates


### PR DESCRIPTION
## Summary
- Local push site creation and restore polling loops now handle task error status gracefully instead of looping indefinitely.
- Local push now uses current site WP and PHP versions instead of hardcoded 6.3/7.4.
- Local push now creates a reserved site for better reliability.

## Test plan
- [ ] Run `wp instawp local push` from a connected local site
- [ ] Verify staging site is created with correct WP/PHP versions
- [ ] Verify restore failure is handled gracefully (migration marked as failed, not stuck)
- [ ] Verify successful push completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)