### PR TITLE
fix: skip connect plugin deletion if site is connected

### DIFF
--- a/includes/apis/class-instawp-rest-api-migration.php
+++ b/includes/apis/class-instawp-rest-api-migration.php
@@ -364,7 +364,9 @@ class InstaWP_Rest_Api_Migration extends InstaWP_Rest_Api {
 			}
 
 			// Adding instawp-connect plugin to delete after the migration if delete connect plugin flag is enabled
-			if ( $delete_connect_plugin ) {
+			// Skip if site has an active connect_id — plugin is still needed for the connection
+			$connect_id = instawp_get_connect_id();
+			if ( $delete_connect_plugin && empty( $connect_id ) ) {
 				$plugins_to_delete[] = array(
 					'slug'   => $plugin_slug,
 					'type'   => 'plugin',

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 - Improved: Local push site creation and restore now handle task errors gracefully.
 - Improved: Local push now uses current site WP and PHP versions for staging site.
 - Improved: Local push now creates a reserved site for better reliability.
+- Improved: Migration cleanup will no longer remove the InstaWP Connect plugin if the site is connected and managed via InstaWP.
 
 = 0.1.3.0 - 31 March 2026 =
 - Fixed: Improved response details


### PR DESCRIPTION
## Summary
- Migration cleanup now checks for an active `connect_id` before deleting the InstaWP Connect plugin
- If the site is connected and managed via InstaWP, the plugin is preserved post-migration
- Updated changelog in readme.txt

## Test plan
- [ ] Run a migration on a site that IS connected (has connect_id) — verify plugin is NOT deleted
- [ ] Run a migration on a site that is NOT connected — verify plugin IS deleted when `delete_connect_plugin` flag is enabled
- [ ] Verify existing migration flows are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)