### PR TITLE
fix: hard-guard instawp-connect from deletion in post-migration cleanup

### DIFF
--- a/includes/apis/class-instawp-rest-api-migration.php
+++ b/includes/apis/class-instawp-rest-api-migration.php
@@ -379,6 +379,28 @@ class InstaWP_Rest_Api_Migration extends InstaWP_Rest_Api {
 				InstaWP_Tools::clean_iwp_files_dir();
 			}
 
+			// Hard guard: if instawp-connect is in the delete list and the site is
+			// still connected or is a staging site, remove it. Covers every path
+			// that can append it (white-label post_uninstalls, delete_connect_plugin
+			// default, future code). Reuses $connect_id from the pre-filter above.
+			$connect_index = array_search( $plugin_slug, array_column( $plugins_to_delete, 'slug' ), true );
+			if ( false !== $connect_index ) {
+				$is_staging_site = (bool) Option::get_option( 'instawp_is_staging' );
+				$parent_connect  = Option::get_option( 'instawp_sync_connect_id' );
+
+				if ( ! empty( $connect_id ) || $is_staging_site || ! empty( $parent_connect ) ) {
+					unset( $plugins_to_delete[ $connect_index ] );
+					Helper::add_error_log(
+						'Removed instawp-connect from post_migration_cleanup delete list — site is connected/staging',
+						array(
+							'connect_id'        => $connect_id,
+							'is_staging'        => $is_staging_site,
+							'parent_connect_id' => $parent_connect,
+						)
+					);
+				}
+			}
+
 			foreach ( $plugins_to_delete as $plugin ) {
 
 				$_slug   = InstaWP_Setting::get_args_option( 'slug', $plugin );


### PR DESCRIPTION
## Summary
- Adds a hard guard inside `handle_post_migration_cleanup()` that removes `instawp-connect` from `$plugins_to_delete` whenever the site is still connected (non-empty `connect_id`), flagged as a staging site (`instawp_is_staging`), or has a parent connect reference (`instawp_sync_connect_id`).
- Closes the gap left by the existing pre-filter (lines 368-375), which only covered the `delete_connect_plugin` auto-append path and missed entries coming from white-label `post_uninstalls` payloads.
- Uses `array_search(..., array_column($plugins_to_delete, 'slug'))` so the DB options are only read when the plugin slug is actually in the delete list — no extra option reads in the happy path, and `$connect_id` is reused from the pre-filter above.

## Test plan
- [ ] On a non-production InstaWP server, create a staging site from a live site in the plugin UI and confirm `instawp-connect` stays active after the migration-cleanup webhook fires.
- [ ] Grep the staging site's debug log for `Removed instawp-connect from post_migration_cleanup delete list` to confirm the guard ran.
- [ ] Regression: run an end-to-end push migration where the destination is non-InstaWP; confirm `instawp-connect` and helper plugins are still cleaned up on the destination as before (guard only skips when the site is connected/staging — the push destination is neither).
- [ ] Regression: run an auto-migrate pull from a non-InstaWP source to an InstaWP destination; confirm the plugin remains active on the destination and the Connect dashboard row persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)