### PR TITLE
refactor: make sanitize_wp_config public and return status array

### DIFF
--- a/includes/apis/class-instawp-rest-api-migration.php
+++ b/includes/apis/class-instawp-rest-api-migration.php
@@ -444,21 +444,36 @@ class InstaWP_Rest_Api_Migration extends InstaWP_Rest_Api {
 	 * wp-config.php often contains hardcoded paths that don't exist on the destination server,
 	 * causing Fatal errors and 504 Gateway Timeouts.
 	 *
-	 * @return void
+	 * Public so it can be invoked via WP-CLI `wp eval` from HestiaCP migration scripts
+	 * on pure pull migrations where the post-migration cleanup REST endpoint is not called.
+	 *
+	 * @return array {
+	 *     @type bool   $success  Whether the operation completed without error.
+	 *     @type bool   $modified Whether wp-config.php was actually changed.
+	 *     @type string $message  Human-readable status message.
+	 * }
 	 */
-	private function sanitize_wp_config() {
+	public function sanitize_wp_config() {
 		try {
 			$wp_config_path = ABSPATH . 'wp-config.php';
 			if ( ! file_exists( $wp_config_path ) ) {
 				$wp_config_path = dirname( ABSPATH ) . '/wp-config.php';
 			}
 			if ( ! file_exists( $wp_config_path ) || ! is_writable( $wp_config_path ) ) {
-				return;
+				return array(
+					'success'  => false,
+					'modified' => false,
+					'message'  => 'wp-config.php not found or not writable.',
+				);
 			}
 
 			$content = file_get_contents( $wp_config_path );
 			if ( empty( $content ) ) {
-				return;
+				return array(
+					'success'  => false,
+					'modified' => false,
+					'message'  => 'wp-config.php is empty or unreadable.',
+				);
 			}
 
 			$modified = false;
@@ -580,11 +595,34 @@ class InstaWP_Rest_Api_Migration extends InstaWP_Rest_Api {
 			}
 
 			if ( $modified ) {
-				file_put_contents( $wp_config_path, $content );
+				$bytes = file_put_contents( $wp_config_path, $content );
+				if ( false === $bytes ) {
+					return array(
+						'success'  => false,
+						'modified' => false,
+						'message'  => 'Failed to write sanitized wp-config.php.',
+					);
+				}
+				return array(
+					'success'  => true,
+					'modified' => true,
+					'message'  => 'wp-config.php sanitized successfully.',
+				);
 			}
+
+			return array(
+				'success'  => true,
+				'modified' => false,
+				'message'  => 'wp-config.php already clean, no changes needed.',
+			);
 		} catch ( \Throwable $e ) {
 			// Sanitization failure should never break the migration.
 			Helper::add_error_log( 'wp-config sanitization error: ' . $e->getMessage(), $e );
+			return array(
+				'success'  => false,
+				'modified' => false,
+				'message'  => 'wp-config sanitization error: ' . $e->getMessage(),
+			);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Changes `InstaWP_Rest_Api_Migration::sanitize_wp_config()` from `private` to `public` so external callers (specifically the HestiaCP migration scripts in instacp) can invoke it via `wp eval` for pure pull migrations where `handle_post_migration_cleanup` is not triggered.
- Return type changes from `void` to an array with `{success, modified, message}` keys, covering every exit point in the function — not-writable, empty/unreadable content, write-failure, successful-write, no-changes-needed, and the catch block.
- Internal callsite in `handle_post_migration_cleanup` (line 275) continues to call `$this->sanitize_wp_config()` and simply discards the return value — no behavioural change for the REST path.

## Why
Builds on #495 (merged) which added the hard guard against plugin deletion. That fix relies on the staging site running develop-branch code. A paired change in `instacp/v-instawp-migrate-pull` (see InstaWP/instacp#355) now invokes this method directly via `wp eval` on dev/stage control planes after self-updating the plugin to develop. For that external call to work the method must be public, and for the migration log to show a useful status line it must return a structured result.

## Test plan
- [ ] `php -l` passes on `includes/apis/class-instawp-rest-api-migration.php`.
- [ ] Run a pure pull migration (create staging from live) on a dev control plane. Confirm the instacp script log shows `sanitize_wp_config: wp-config.php sanitized successfully.` (or "already clean") in the migration output.
- [ ] Regression: trigger `handle_post_migration_cleanup` via an e2e migration. Confirm the existing REST cleanup path still runs sanitize internally (the `$this->sanitize_wp_config()` call on line 275 still works, return value is discarded).
- [ ] Regression: hit an unwritable wp-config (chmod 444) on a test site and confirm the method returns `success=false` with the "not found or not writable" message, and the migration doesn't crash.

## Related
- InstaWP/instawp-connect#495 (merged) — the hard-guard fix.
- InstaWP/instacp#355 — the paired instacp change that calls this method via `wp eval`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)