### PR TITLE
fix: use soft reset for connected sites in post-migration cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,19 @@ All code must be:
 - Use feature detection instead of version checks where possible
 - Deprecate old functions gracefully before removal
 
+### Variable Declaration Before Use
+- **NEVER use a variable before declaring it** — even if PHP won't fatal on it, it produces bugs and undefined behavior
+- Before writing any code block that references a variable, verify where that variable is declared in the current scope
+- When moving code blocks (e.g., reordering logic), trace ALL variable dependencies and move declarations above their first use
+- When adding new code that references an existing variable, confirm the declaration line number is ABOVE the new code — do not assume
+
+### Self-Review Before Presenting Edits
+- After writing an edit, re-read the FULL diff and trace every variable reference to its declaration
+- Check that no variable is used before its assignment in the new ordering
+- Check that moved/deleted code doesn't leave dangling references
+- If an edit reorders logic, draw the dependency chain: which variables feed into which lines, and does the new order satisfy all dependencies?
+- Do NOT rely on the user to catch scope errors — catch them yourself before presenting
+
 ### Syntax Error Free
 - All code must be free of syntax errors before committing
 - Validate PHP syntax using `php -l filename.php` before finalizing changes

--- a/includes/apis/class-instawp-rest-api-migration.php
+++ b/includes/apis/class-instawp-rest-api-migration.php
@@ -342,9 +342,19 @@ class InstaWP_Rest_Api_Migration extends InstaWP_Rest_Api {
 
 			Option::update_option( 'instawp_last_migration_details', $migration_details );
 
-			// reset everything and remove connection
+			$connect_id = instawp_get_connect_id();
+
+			// Reset migration state. Connected sites (with a valid connect_id)
+			// get a soft reset that cleans migration temp data only — their
+			// instawp_api_options, instawp_is_staging etc. must survive so the
+			// site stays connected to the dashboard. Disconnected sites get the
+			// full hard reset + server-side disconnect as before.
 			if ( $clear_connect ) {
-				instawp_reset_running_migration( 'hard', true );
+				if ( ! empty( $connect_id ) ) {
+					instawp_reset_running_migration();
+				} else {
+					instawp_reset_running_migration( 'hard', true );
+				}
 			}
 
 			$post_uninstalls = $request->get_param( 'post_uninstalls' );
@@ -365,7 +375,6 @@ class InstaWP_Rest_Api_Migration extends InstaWP_Rest_Api {
 
 			// Adding instawp-connect plugin to delete after the migration if delete connect plugin flag is enabled
 			// Skip if site has an active connect_id — plugin is still needed for the connection
-			$connect_id = instawp_get_connect_id();
 			if ( $delete_connect_plugin && empty( $connect_id ) ) {
 				$plugins_to_delete[] = array(
 					'slug'   => $plugin_slug,


### PR DESCRIPTION
## Summary
- `handle_post_migration_cleanup()` was calling `instawp_reset_running_migration('hard', true)` unconditionally when `clear_connect` was set. The hard reset deletes `instawp_api_options`, `instawp_is_staging`, and other critical options — leaving connected staging sites unable to authenticate or heartbeat to the dashboard after pull migration.
- Now checks `instawp_get_connect_id()` first: if a valid `connect_id` exists, the site is actively connected, so only a soft reset runs (cleans migration temp data like `instawp_migration_details` and backup files). Disconnected sites still get the full hard reset + server-side disconnect as before.
- Moves `$connect_id` declaration above all its uses (reset block + plugin-delete guard + hard guard) so there's a single `instawp_get_connect_id()` call shared by all three code paths.
- Adds "Variable Declaration Before Use" and "Self-Review Before Presenting Edits" principles to CLAUDE.md.

## Root cause
When client-app's `pluginCleanUpAutoMigrate` calls `/v3/post-cleanup` after a successful pull migration, it omits the `clear_connect` parameter. The handler defaults `clear_connect` to `true`, triggering `instawp_reset_running_migration('hard', true)` which wipes `instawp_api_options` (including `api_key`, `connect_id`, `api_url`) and `instawp_is_staging`. The staging site then can't authenticate to the InstaWP server, heartbeats fail, and the dashboard shows "disconnected".

## Test plan
- [ ] Create a staging site from a live InstaWP site on dev5. After migration completes, verify:
  - `wp option get instawp_api_options` returns a valid array with `api_key`, `connect_id`, `api_url`
  - `wp option get instawp_is_staging` returns `1`
  - `wp option get instawp_heartbeat_failed` stays at `0` after a page load
- [ ] Regression: trigger a migration to a non-connected external destination (no `connect_id`). Verify the hard reset still runs and cleans up fully.
- [ ] Regression: abort a migration mid-flight. Verify cleanup still runs the hard reset path (destination has no valid `connect_id` mid-migration).

## Related
- InstaWP/instawp-connect#495 (merged) — hard guard for plugin deletion
- InstaWP/instawp-connect#496 (merged) — sanitize_wp_config public
- InstaWP/instacp#355 — instacp-side `config-set api-domain` fix (paired defense-in-depth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)