### PR TITLE
fix: route /serve-instawp/ to iwp-serve/index.php after rename

### DIFF
--- a/includes/class-instawp-hooks.php
+++ b/includes/class-instawp-hooks.php
@@ -53,7 +53,7 @@ if ( ! class_exists( 'InstaWP_Hooks' ) ) {
 
 		public function handle_migration_through_wp( $wp ) {
 			if ( isset( $wp->query_vars['instawp_serve'] ) ) {
-				$serve_file = INSTAWP_PLUGIN_DIR . 'serve.php';
+				$serve_file = INSTAWP_PLUGIN_DIR . 'iwp-serve' . DIRECTORY_SEPARATOR . 'index.php';
 
 				if ( file_exists( $serve_file ) ) {
 					// Prevent WordPress from loading further
@@ -62,6 +62,10 @@ if ( ! class_exists( 'InstaWP_Hooks' ) ) {
 					include_once $serve_file;
 					exit;
 				} else {
+					Helper::add_error_log( array(
+						'title'      => 'serve-instawp: migration serve file missing',
+						'serve_file' => $serve_file,
+					) );
 					header( 'HTTP/1.0 404 Not Found' );
 					exit( 'File not found' );
 				}

--- a/includes/class-instawp-tools.php
+++ b/includes/class-instawp-tools.php
@@ -1589,7 +1589,7 @@ include $file_path;';
 			return new WP_Error( 404, esc_html__( 'API Signature and others data could not set properly', 'instawp-connect' ) );
 		}
 
-		// Check accessibility of serve.php file
+		// Check accessibility of iwp-serve/index.php
 		$server_res = self::get_serve_url( $serve_url );
 
 		$serve_url     = $server_res['serve_url'];

--- a/instawp-connect.php
+++ b/instawp-connect.php
@@ -8,7 +8,7 @@
  * @wordpress-plugin
  * Plugin Name:       InstaWP Connect
  * Description:       1-click WordPress plugin for Staging, Migrations, Management, Sync and Companion plugin for InstaWP.
- * Version:           0.1.3.0
+ * Version:           0.1.3.1
  * Author:            InstaWP Team
  * Author URI:        https://instawp.com/
  * License:           GPL-3.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 global $wpdb;
 
-defined( 'INSTAWP_PLUGIN_VERSION' ) || define( 'INSTAWP_PLUGIN_VERSION', '0.1.3.0' );
+defined( 'INSTAWP_PLUGIN_VERSION' ) || define( 'INSTAWP_PLUGIN_VERSION', '0.1.3.1' );
 defined( 'INSTAWP_API_DOMAIN_PROD' ) || define( 'INSTAWP_API_DOMAIN_PROD', 'https://app.instawp.io' );
 
 defined( 'INSTAWP_PLUGIN_URL' ) || define( 'INSTAWP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: clone, migrate, staging, backup, restore
 Requires at least: 5.6
 Tested up to: 6.9
 Requires PHP: 7.0
-Stable tag: 0.1.3.0
+Stable tag: 0.1.3.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 
@@ -99,11 +99,12 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 == Changelog ==
 
 
-= 0.1.3.1 - Beta =
+= 0.1.3.1 - 22 April 2026 =
 - Improved: Local push site creation and restore now handle task errors gracefully.
 - Improved: Local push now uses current site WP and PHP versions for staging site.
 - Improved: Local push now creates a reserved site for better reliability.
 - Improved: Migration cleanup will no longer remove the InstaWP Connect plugin if the site is connected and managed via InstaWP.
+- Fixed: Serve URL 404 error on `/serve-instawp/` WordPress-routed migration fallback.
 
 = 0.1.3.0 - 31 March 2026 =
 - Fixed: Improved response details


### PR DESCRIPTION
## Summary
- `InstaWP_Hooks::handle_migration_through_wp()` referenced the old `INSTAWP_PLUGIN_DIR . 'serve.php'` path, which no longer exists since commit `67250b0c` (Feb 11, 2025) moved the serve script to `iwp-serve/index.php`. Any migration that fell back to the WP-routed URL (`/serve-instawp/`) would 404 with body `File not found`, causing the source-side migration loop to retry forever.
- Updated the handler to include `INSTAWP_PLUGIN_DIR . 'iwp-serve/index.php'` and added a `Helper::add_error_log()` call on the missing-file branch so any future path regression surfaces in logs.
- Bumped version to `0.1.3.1` and added changelog entry.

## Root cause
```
# Before (class-instawp-hooks.php:56)
$serve_file = INSTAWP_PLUGIN_DIR . 'serve.php';           # never exists → 404

# After
$serve_file = INSTAWP_PLUGIN_DIR . 'iwp-serve' . DIRECTORY_SEPARATOR . 'index.php';
```

The user-reported log confirmed this exact failure:
```
URL: https://<site>/serve-instawp/. Request 19 is: 404
Full response: "File not found"
```
The body `File not found` is the literal string emitted by the handler's `exit( 'File not found' )` branch — proving the rewrite matched but `file_exists()` checked the stale path.

## Test plan
- [x] `php -l` passes on both modified files.
- [x] Linked plugin to a test site (`randhir-09.sites.dev5.instawp.me`), activated, flushed permalinks.
- [x] `POST /serve-instawp/` with invalid `migrate_key`/`api_signature` → `HTTP 200` with `x-iwp-status: false` and `x-iwp-message: Migration script could not connect to the database...` (previously `HTTP 404 File not found`).
- [x] `GET /serve-instawp/` (empty) → `x-iwp-message: The migration key from fetch script is empty`.
- [x] Direct plugin URL (`/wp-content/plugins/instawp-connect/iwp-serve/`) still returns identical response — WP-routed and direct paths now behave the same.
- [ ] Full pull migration on a site where the direct serve URL is blocked (firewall/ModSecurity) — verify `serve_with_wp=true` path completes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)