### PR TITLE
Release version 0.1.3.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,19 @@ All code must be:
 - Use feature detection instead of version checks where possible
 - Deprecate old functions gracefully before removal
 
+### Variable Declaration Before Use
+- **NEVER use a variable before declaring it** — even if PHP won't fatal on it, it produces bugs and undefined behavior
+- Before writing any code block that references a variable, verify where that variable is declared in the current scope
+- When moving code blocks (e.g., reordering logic), trace ALL variable dependencies and move declarations above their first use
+- When adding new code that references an existing variable, confirm the declaration line number is ABOVE the new code — do not assume
+
+### Self-Review Before Presenting Edits
+- After writing an edit, re-read the FULL diff and trace every variable reference to its declaration
+- Check that no variable is used before its assignment in the new ordering
+- Check that moved/deleted code doesn't leave dangling references
+- If an edit reorders logic, draw the dependency chain: which variables feed into which lines, and does the new order satisfy all dependencies?
+- Do NOT rely on the user to catch scope errors — catch them yourself before presenting
+
 ### Syntax Error Free
 - All code must be free of syntax errors before committing
 - Validate PHP syntax using `php -l filename.php` before finalizing changes

--- a/includes/apis/class-instawp-rest-api-migration.php
+++ b/includes/apis/class-instawp-rest-api-migration.php
@@ -444,21 +444,36 @@ class InstaWP_Rest_Api_Migration extends InstaWP_Rest_Api {
 	 * wp-config.php often contains hardcoded paths that don't exist on the destination server,
 	 * causing Fatal errors and 504 Gateway Timeouts.
 	 *
-	 * @return void
+	 * Public so it can be invoked via WP-CLI `wp eval` from HestiaCP migration scripts
+	 * on pure pull migrations where the post-migration cleanup REST endpoint is not called.
+	 *
+	 * @return array {
+	 *     @type bool   $success  Whether the operation completed without error.
+	 *     @type bool   $modified Whether wp-config.php was actually changed.
+	 *     @type string $message  Human-readable status message.
+	 * }
 	 */
-	private function sanitize_wp_config() {
+	public function sanitize_wp_config() {
 		try {
 			$wp_config_path = ABSPATH . 'wp-config.php';
 			if ( ! file_exists( $wp_config_path ) ) {
 				$wp_config_path = dirname( ABSPATH ) . '/wp-config.php';
 			}
 			if ( ! file_exists( $wp_config_path ) || ! is_writable( $wp_config_path ) ) {
-				return;
+				return array(
+					'success'  => false,
+					'modified' => false,
+					'message'  => 'wp-config.php not found or not writable.',
+				);
 			}
 
 			$content = file_get_contents( $wp_config_path );
 			if ( empty( $content ) ) {
-				return;
+				return array(
+					'success'  => false,
+					'modified' => false,
+					'message'  => 'wp-config.php is empty or unreadable.',
+				);
 			}
 
 			$modified = false;
@@ -580,11 +595,34 @@ class InstaWP_Rest_Api_Migration extends InstaWP_Rest_Api {
 			}
 
 			if ( $modified ) {
-				file_put_contents( $wp_config_path, $content );
+				$bytes = file_put_contents( $wp_config_path, $content );
+				if ( false === $bytes ) {
+					return array(
+						'success'  => false,
+						'modified' => false,
+						'message'  => 'Failed to write sanitized wp-config.php.',
+					);
+				}
+				return array(
+					'success'  => true,
+					'modified' => true,
+					'message'  => 'wp-config.php sanitized successfully.',
+				);
 			}
+
+			return array(
+				'success'  => true,
+				'modified' => false,
+				'message'  => 'wp-config.php already clean, no changes needed.',
+			);
 		} catch ( \Throwable $e ) {
 			// Sanitization failure should never break the migration.
 			Helper::add_error_log( 'wp-config sanitization error: ' . $e->getMessage(), $e );
+			return array(
+				'success'  => false,
+				'modified' => false,
+				'message'  => 'wp-config sanitization error: ' . $e->getMessage(),
+			);
 		}
 	}
 }

--- a/includes/apis/class-instawp-rest-api-migration.php
+++ b/includes/apis/class-instawp-rest-api-migration.php
@@ -342,9 +342,19 @@ class InstaWP_Rest_Api_Migration extends InstaWP_Rest_Api {
 
 			Option::update_option( 'instawp_last_migration_details', $migration_details );
 
-			// reset everything and remove connection
+			$connect_id = instawp_get_connect_id();
+
+			// Reset migration state. Connected sites (with a valid connect_id)
+			// get a soft reset that cleans migration temp data only — their
+			// instawp_api_options, instawp_is_staging etc. must survive so the
+			// site stays connected to the dashboard. Disconnected sites get the
+			// full hard reset + server-side disconnect as before.
 			if ( $clear_connect ) {
-				instawp_reset_running_migration( 'hard', true );
+				if ( ! empty( $connect_id ) ) {
+					instawp_reset_running_migration();
+				} else {
+					instawp_reset_running_migration( 'hard', true );
+				}
 			}
 
 			$post_uninstalls = $request->get_param( 'post_uninstalls' );
@@ -365,7 +375,6 @@ class InstaWP_Rest_Api_Migration extends InstaWP_Rest_Api {
 
 			// Adding instawp-connect plugin to delete after the migration if delete connect plugin flag is enabled
 			// Skip if site has an active connect_id — plugin is still needed for the connection
-			$connect_id = instawp_get_connect_id();
 			if ( $delete_connect_plugin && empty( $connect_id ) ) {
 				$plugins_to_delete[] = array(
 					'slug'   => $plugin_slug,

--- a/includes/apis/class-instawp-rest-api-migration.php
+++ b/includes/apis/class-instawp-rest-api-migration.php
@@ -364,7 +364,9 @@ class InstaWP_Rest_Api_Migration extends InstaWP_Rest_Api {
 			}
 
 			// Adding instawp-connect plugin to delete after the migration if delete connect plugin flag is enabled
-			if ( $delete_connect_plugin ) {
+			// Skip if site has an active connect_id — plugin is still needed for the connection
+			$connect_id = instawp_get_connect_id();
+			if ( $delete_connect_plugin && empty( $connect_id ) ) {
 				$plugins_to_delete[] = array(
 					'slug'   => $plugin_slug,
 					'type'   => 'plugin',

--- a/includes/apis/class-instawp-rest-api-migration.php
+++ b/includes/apis/class-instawp-rest-api-migration.php
@@ -379,6 +379,28 @@ class InstaWP_Rest_Api_Migration extends InstaWP_Rest_Api {
 				InstaWP_Tools::clean_iwp_files_dir();
 			}
 
+			// Hard guard: if instawp-connect is in the delete list and the site is
+			// still connected or is a staging site, remove it. Covers every path
+			// that can append it (white-label post_uninstalls, delete_connect_plugin
+			// default, future code). Reuses $connect_id from the pre-filter above.
+			$connect_index = array_search( $plugin_slug, array_column( $plugins_to_delete, 'slug' ), true );
+			if ( false !== $connect_index ) {
+				$is_staging_site = (bool) Option::get_option( 'instawp_is_staging' );
+				$parent_connect  = Option::get_option( 'instawp_sync_connect_id' );
+
+				if ( ! empty( $connect_id ) || $is_staging_site || ! empty( $parent_connect ) ) {
+					unset( $plugins_to_delete[ $connect_index ] );
+					Helper::add_error_log(
+						'Removed instawp-connect from post_migration_cleanup delete list — site is connected/staging',
+						array(
+							'connect_id'        => $connect_id,
+							'is_staging'        => $is_staging_site,
+							'parent_connect_id' => $parent_connect,
+						)
+					);
+				}
+			}
+
 			foreach ( $plugins_to_delete as $plugin ) {
 
 				$_slug   = InstaWP_Setting::get_args_option( 'slug', $plugin );

--- a/includes/class-instawp-cli.php
+++ b/includes/class-instawp-cli.php
@@ -40,7 +40,7 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 			delete_option( 'instawp_parent_is_on_local' );
 
 			// Create Site
-			if ( is_wp_error( $create_site_res = InstaWP_Tools::create_insta_site() ) ) {
+			if ( is_wp_error( $create_site_res = InstaWP_Tools::create_insta_site( true ) ) ) {
 				die( esc_html( $create_site_res->get_error_message() ) );
 			}
 

--- a/includes/class-instawp-hooks.php
+++ b/includes/class-instawp-hooks.php
@@ -53,7 +53,7 @@ if ( ! class_exists( 'InstaWP_Hooks' ) ) {
 
 		public function handle_migration_through_wp( $wp ) {
 			if ( isset( $wp->query_vars['instawp_serve'] ) ) {
-				$serve_file = INSTAWP_PLUGIN_DIR . 'serve.php';
+				$serve_file = INSTAWP_PLUGIN_DIR . 'iwp-serve' . DIRECTORY_SEPARATOR . 'index.php';
 
 				if ( file_exists( $serve_file ) ) {
 					// Prevent WordPress from loading further
@@ -62,6 +62,10 @@ if ( ! class_exists( 'InstaWP_Hooks' ) ) {
 					include_once $serve_file;
 					exit;
 				} else {
+					Helper::add_error_log( array(
+						'title'      => 'serve-instawp: migration serve file missing',
+						'serve_file' => $serve_file,
+					) );
 					header( 'HTTP/1.0 404 Not Found' );
 					exit( 'File not found' );
 				}

--- a/includes/class-instawp-tools.php
+++ b/includes/class-instawp-tools.php
@@ -2050,21 +2050,22 @@ include $file_path;';
 		return new WP_Error( 'no_method_find', esc_html__( 'No compression method find.', 'instawp-connect' ) );
 	}
 
-	public static function create_insta_site() {
+	public static function create_insta_site( $is_reserved = false ) {
 		$connect_id = instawp_get_connect_id();
 
 		// Creating new blank site
 		$sites_args        = array(
-			'wp_version'  => '6.3',
-			'php_version' => '7.4',
-			'is_reserved' => false,
+			'wp_version'  => function_exists('get_bloginfo') ? get_bloginfo( 'version' ): '6.9.4',
+			'php_version' => function_exists('phpversion') ? phpversion(): '8.3',
+			'is_reserved' => $is_reserved,
 		);
+
 		$sites_res         = Curl::do_curl( "connects/{$connect_id}/sites/create-staging", $sites_args );
 		$sites_res_status  = (bool) Helper::get_args_option( 'success', $sites_res, true );
-		$sites_res_message = Helper::get_args_option( 'message', $sites_res, true );
+		$sites_res_message = Helper::get_args_option( 'message', $sites_res );
 
 		if ( ! $sites_res_status ) {
-			return new WP_Error( 'could_not_create_site', $sites_res_message );
+			return new WP_Error( 'could_not_create_site', sanitize_text_field( $sites_res_message ) );
 		}
 
 		$sites_res_data = Helper::get_args_option( 'data', $sites_res, array() );
@@ -2085,7 +2086,12 @@ include $file_path;';
 
 				error_log( "local_push_migration_progress: {$percentage_complete}" );
 
-				if ( $restore_status === 'completed' ) {
+				if ( $restore_status === 'error' ) {
+					$comment      = Helper::get_args_option( 'comment', $status_res_data, 'Error: ' . esc_html__( 'Failed to create site with WordPress ', 'instawp-connect' ) . $sites_args['wp_version'] . '& Php ' . $sites_args['php_version'] );
+					$comment = explode('Error:', $comment, 2);
+					return new WP_Error( 'could_not_create_site', sanitize_text_field( isset($comment[1]) ? $comment[1] : $comment[0] ) );
+					break;
+				} else if ( $restore_status === 'completed' ) {
 					break;
 				}
 
@@ -2191,7 +2197,12 @@ include $file_path;';
 
 			error_log( "local_push_migration_progress: {$percentage_complete}" );
 
-			if ( $restore_status === 'completed' ) {
+			if ( $restore_status === 'error' ) {
+				$comment      = Helper::get_args_option( 'comment', $status_res_data, 'Error: ' . esc_html__( 'Failed to restore the created site from the given backup.', 'instawp-connect' ) );
+				$comment = explode('Error:', $comment, 2);
+				return new WP_Error( 'restore_raw_api_failed', sanitize_text_field( isset($comment[1]) ? $comment[1] : $comment[0] ) );
+				break;
+			} else if ( $restore_status === 'completed' ) {
 				break;
 			}
 

--- a/includes/class-instawp-tools.php
+++ b/includes/class-instawp-tools.php
@@ -1589,7 +1589,7 @@ include $file_path;';
 			return new WP_Error( 404, esc_html__( 'API Signature and others data could not set properly', 'instawp-connect' ) );
 		}
 
-		// Check accessibility of serve.php file
+		// Check accessibility of iwp-serve/index.php
 		$server_res = self::get_serve_url( $serve_url );
 
 		$serve_url     = $server_res['serve_url'];

--- a/instawp-connect.php
+++ b/instawp-connect.php
@@ -8,7 +8,7 @@
  * @wordpress-plugin
  * Plugin Name:       InstaWP Connect
  * Description:       1-click WordPress plugin for Staging, Migrations, Management, Sync and Companion plugin for InstaWP.
- * Version:           0.1.3.0
+ * Version:           0.1.3.1
  * Author:            InstaWP Team
  * Author URI:        https://instawp.com/
  * License:           GPL-3.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 global $wpdb;
 
-defined( 'INSTAWP_PLUGIN_VERSION' ) || define( 'INSTAWP_PLUGIN_VERSION', '0.1.3.0' );
+defined( 'INSTAWP_PLUGIN_VERSION' ) || define( 'INSTAWP_PLUGIN_VERSION', '0.1.3.1' );
 defined( 'INSTAWP_API_DOMAIN_PROD' ) || define( 'INSTAWP_API_DOMAIN_PROD', 'https://app.instawp.io' );
 
 defined( 'INSTAWP_PLUGIN_URL' ) || define( 'INSTAWP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: clone, migrate, staging, backup, restore
 Requires at least: 5.6
 Tested up to: 6.9
 Requires PHP: 7.0
-Stable tag: 0.1.3.0
+Stable tag: 0.1.3.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 
@@ -99,11 +99,12 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 == Changelog ==
 
 
-= 0.1.3.1 - Beta =
+= 0.1.3.1 - 22 April 2026 =
 - Improved: Local push site creation and restore now handle task errors gracefully.
 - Improved: Local push now uses current site WP and PHP versions for staging site.
 - Improved: Local push now creates a reserved site for better reliability.
 - Improved: Migration cleanup will no longer remove the InstaWP Connect plugin if the site is connected and managed via InstaWP.
+- Fixed: Serve URL 404 error on `/serve-instawp/` WordPress-routed migration fallback.
 
 = 0.1.3.0 - 31 March 2026 =
 - Fixed: Improved response details

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 - Improved: Local push site creation and restore now handle task errors gracefully.
 - Improved: Local push now uses current site WP and PHP versions for staging site.
 - Improved: Local push now creates a reserved site for better reliability.
+- Improved: Migration cleanup will no longer remove the InstaWP Connect plugin if the site is connected and managed via InstaWP.
 
 = 0.1.3.0 - 31 March 2026 =
 - Fixed: Improved response details

--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,12 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
+
+= 0.1.3.1 - Beta =
+- Improved: Local push site creation and restore now handle task errors gracefully.
+- Improved: Local push now uses current site WP and PHP versions for staging site.
+- Improved: Local push now creates a reserved site for better reliability.
+
 = 0.1.3.0 - 31 March 2026 =
 - Fixed: Improved response details
 - Optimized: Plugin and theme updates


### PR DESCRIPTION
- Improved: Local push site creation and restore now handle task errors gracefully.
- Improved: Local push now uses current site WP and PHP versions for staging site.
- Improved: Local push now creates a reserved site for better reliability.
- Improved: Migration cleanup will no longer remove the InstaWP Connect plugin if the site is connected and managed via InstaWP.
- Fixed: Serve URL 404 error on `/serve-instawp/` WordPress-routed migration fallback.