### PR TITLE
Fix two-way sync plugin/theme action warnings + bump to 0.1.3.4

### DIFF
--- a/includes/sync/class-instawp-sync-plugin-theme.php
+++ b/includes/sync/class-instawp-sync-plugin-theme.php
@@ -551,10 +551,10 @@ class InstaWP_Sync_Plugin_Theme {
 			}
 
 			if ( $this->is_plugin_installed( $v->details ) ) {
-				$response = $this->activate_item( $v->details, 'plugin' )[0];
+				$response = $this->get_item_response( $this->activate_item( $v->details, 'plugin' ), $v->details );
 
-				if ( ! $response['success'] ) {
-					$logs[ $v->id ] = $response['message'];
+				if ( empty( $response['success'] ) ) {
+					$logs[ $v->id ] = $response['message'] ?? '';
 
 					return InstaWP_Sync_Helpers::sync_response( $v, $logs, array(
 						'status'  => 'error',
@@ -574,10 +574,10 @@ class InstaWP_Sync_Plugin_Theme {
 		// plugin deactivate
 		if ( $v->event_slug === 'deactivate_plugin' ) {
 			if ( $this->is_plugin_installed( $v->details ) ) {
-				$response = $this->deactivate_item( $v->details );
+				$response = $this->get_item_response( $this->deactivate_item( $v->details ), $v->details );
 
-				if ( ! $response['success'] ) {
-					$logs[ $v->id ] = $response['message'];
+				if ( empty( $response['success'] ) ) {
+					$logs[ $v->id ] = $response['message'] ?? '';
 
 					return InstaWP_Sync_Helpers::sync_response( $v, $logs, array(
 						'status'  => 'error',
@@ -643,10 +643,10 @@ class InstaWP_Sync_Plugin_Theme {
 		// plugin delete
 		if ( $v->event_slug === 'deleted_plugin' ) {
 			if ( $this->is_plugin_installed( $v->details ) ) {
-				$response = $this->uninstall_item( $v->details, 'plugin' )[0];
+				$response = $this->get_item_response( $this->uninstall_item( $v->details, 'plugin' ), $v->details );
 
-				if ( ! $response['success'] ) {
-					$logs[ $v->id ] = $response['message'];
+				if ( empty( $response['success'] ) ) {
+					$logs[ $v->id ] = $response['message'] ?? '';
 
 					return InstaWP_Sync_Helpers::sync_response( $v, $logs, array(
 						'status'  => 'error',
@@ -714,10 +714,10 @@ class InstaWP_Sync_Plugin_Theme {
 
 			$theme = wp_get_theme( $stylesheet );
 			if ( $theme->exists() ) {
-				$response = $this->activate_item( $stylesheet, 'theme' )[0];
+				$response = $this->get_item_response( $this->activate_item( $stylesheet, 'theme' ), $stylesheet );
 
-				if ( ! $response['success'] ) {
-					$logs[ $v->id ] = $response['message'];
+				if ( empty( $response['success'] ) ) {
+					$logs[ $v->id ] = $response['message'] ?? '';
 
 					return InstaWP_Sync_Helpers::sync_response( $v, $logs, array(
 						'status'  => 'error',
@@ -772,10 +772,10 @@ class InstaWP_Sync_Plugin_Theme {
 			$theme      = wp_get_theme( $stylesheet );
 
 			if ( $theme->exists() ) {
-				$response = $this->uninstall_item( $stylesheet, 'theme' )[0];
+				$response = $this->get_item_response( $this->uninstall_item( $stylesheet, 'theme' ), $stylesheet );
 
-				if ( ! $response['success'] ) {
-					$logs[ $v->id ] = $response['message'];
+				if ( empty( $response['success'] ) ) {
+					$logs[ $v->id ] = $response['message'] ?? '';
 
 					return InstaWP_Sync_Helpers::sync_response( $v, $logs, array(
 						'status'  => 'error',
@@ -853,9 +853,40 @@ class InstaWP_Sync_Plugin_Theme {
 	 * Plugin deactivate
 	 */
 	public function deactivate_item( $plugin ) {
-		$deactivator = new Deactivator( array( $plugin ) );
+		// Deactivator expects each item as an [ 'asset' => ..., 'type' => ... ] pair.
+		// Passing a bare string skipped deactivation and returned "Required parameters are missing!".
+		$deactivator = new Deactivator( array(
+			array(
+				'asset' => $plugin,
+				'type'  => 'plugin',
+			),
+		) );
 
 		return $deactivator->deactivate();
+	}
+
+	/**
+	 * Normalize an item-action response (activate / deactivate / uninstall).
+	 *
+	 * Activator/Deactivator/Uninstaller return results keyed by asset slug, while
+	 * Installer keys them numerically. Resolves the single result for the given
+	 * asset, falling back to the first numeric entry, then the response itself.
+	 *
+	 * @param mixed  $response Raw response from the helper class.
+	 * @param string $asset    Asset slug used as the array key (plugin path / theme stylesheet).
+	 * @return array
+	 */
+	private function get_item_response( $response, $asset ) {
+		if ( ! is_array( $response ) ) {
+			return array();
+		}
+		if ( isset( $response[ $asset ] ) ) {
+			return $response[ $asset ];
+		}
+		if ( isset( $response[0] ) ) {
+			return $response[0];
+		}
+		return $response;
 	}
 
 	/**

--- a/instawp-connect.php
+++ b/instawp-connect.php
@@ -8,7 +8,7 @@
  * @wordpress-plugin
  * Plugin Name:       InstaWP Connect
  * Description:       1-click WordPress plugin for Staging, Migrations, Management, Sync and Companion plugin for InstaWP.
- * Version:           0.1.3.3
+ * Version:           0.1.3.4
  * Author:            InstaWP Team
  * Author URI:        https://instawp.com/
  * License:           GPL-3.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 global $wpdb;
 
-defined( 'INSTAWP_PLUGIN_VERSION' ) || define( 'INSTAWP_PLUGIN_VERSION', '0.1.3.3' );
+defined( 'INSTAWP_PLUGIN_VERSION' ) || define( 'INSTAWP_PLUGIN_VERSION', '0.1.3.4' );
 defined( 'INSTAWP_API_DOMAIN_PROD' ) || define( 'INSTAWP_API_DOMAIN_PROD', 'https://app.instawp.io' );
 
 defined( 'INSTAWP_PLUGIN_URL' ) || define( 'INSTAWP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: instawp
 Tags: clone, migrate, staging, backup, restore
 Requires at least: 5.6
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 7.0
-Stable tag: 0.1.3.3
+Stable tag: 0.1.3.4
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 
@@ -97,6 +97,11 @@ Need support or want to partner with us? Go to our [website](http://instawp.com/
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team helps validate, triage, and handle any security vulnerabilities. [Report a security vulnerability](https://patchstack.com/database/vdp/instawp-connect).
 
 == Changelog ==
+
+= 0.1.3.4 - Beta =
+- Added: Migration engine detection — end-to-end migrations now auto-route to the v3 or v4 (InstaMigrate) flow.
+- Fixed: Two-way sync no longer emits PHP warnings and now correctly reports plugin/theme activate, deactivate, and delete results.
+- Updated: Dependency packages.
 
 = 0.1.3.3 - 19 May 2026 =
 - Added: WordPress core rollback support — the plugin now snapshots the current core version before every core upgrade and can roll back to that recorded version on request.

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -7,19 +7,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/InstaWP/connect-helpers.git",
-                "reference": "2795feb9935b51f707ded82709438b5d5796a778"
+                "reference": "e40678f5a7fd3e678e2706a0e72af76b97a3fd5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/InstaWP/connect-helpers/zipball/2795feb9935b51f707ded82709438b5d5796a778",
-                "reference": "2795feb9935b51f707ded82709438b5d5796a778",
+                "url": "https://api.github.com/repos/InstaWP/connect-helpers/zipball/e40678f5a7fd3e678e2706a0e72af76b97a3fd5f",
+                "reference": "e40678f5a7fd3e678e2706a0e72af76b97a3fd5f",
                 "shasum": ""
             },
             "require": {
                 "php": ">= 5.6",
                 "wp-cli/wp-config-transformer": "^1.3"
             },
-            "time": "2026-05-18T14:14:01+00:00",
+            "time": "2026-06-09T10:48:48+00:00",
             "default-branch": true,
             "type": "library",
             "installation-source": "dist",

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -22,7 +22,7 @@
         'instawp/connect-helpers' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '2795feb9935b51f707ded82709438b5d5796a778',
+            'reference' => 'e40678f5a7fd3e678e2706a0e72af76b97a3fd5f',
             'type' => 'library',
             'install_path' => __DIR__ . '/../instawp/connect-helpers',
             'aliases' => array(

--- a/vendor/instawp/connect-helpers/changelog.md
+++ b/vendor/instawp/connect-helpers/changelog.md
@@ -1,3 +1,10 @@
+v1.1.2
+======
+- Added: Migration engine detection (v3/v4) via `getMigrationEngine()`.
+- Added: Unified `instaMigrateRequest()` that auto-routes to the v3 (InstaWP Connect) or v4 (InstaMigrate + AI agent) flow.
+- Added: InstaMigrate plugin install helper and API key retrieval.
+- Added: Migration URL and group id getters/setters.
+
 v1.1.1
 ======
 - Added: WordPress core rollback support.

--- a/vendor/instawp/connect-helpers/composer.json
+++ b/vendor/instawp/connect-helpers/composer.json
@@ -2,7 +2,7 @@
     "name": "instawp/connect-helpers",
     "description": "CLI Package for InstaWP Remote Features",
     "type": "library",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "license": "MIT",
     "authors": [
         {

--- a/vendor/instawp/connect-helpers/connect-helpers.php
+++ b/vendor/instawp/connect-helpers/connect-helpers.php
@@ -9,7 +9,7 @@
  *
  * @wordpress-plugin
  * Plugin Name:       InstaWP Connect Helpers
- * Version:           1.1.1
+ * Version:           1.1.2
  * Plugin URI:        https://instawp.com
  * Description:       Helpers Package for InstaWP Remote Features.
  * Author:            InstaWP

--- a/vendor/instawp/connect-helpers/src/Helper.php
+++ b/vendor/instawp/connect-helpers/src/Helper.php
@@ -9,6 +9,311 @@ class Helper {
 	}
 
 	/**
+	 * Get Migration Engine
+	 *
+	 * Hits client-app's GET /api/v2/migrate-v4/engine and returns which migration engine is active
+	 * ('v3' | 'v4') so callers branch their flow before deciding which migration API to hit.
+	 *
+	 * @param string $api_key api key
+	 * @param string $migration_mode optional flow the engine is being resolved for (e.g. 'e2e' | 'push')
+	 *
+	 * @return array
+	 */
+	public static function getMigrationEngine( $api_key, $migration_mode = '' ) {
+		if ( empty( $api_key ) ) {
+			return self::sendResponse( false, 'API key is required.' );
+		}
+
+		// Forward the flow as a query param so client-app knows which flow asked (logged there).
+		$endpoint = ! empty( $migration_mode )
+			? add_query_arg( 'migration_mode', $migration_mode, 'migrate-v4/engine' )
+			: 'migrate-v4/engine';
+
+		$response = Curl::do_curl( $endpoint, array(), array(), 'GET', 'v2', $api_key );
+
+		if ( empty( $response['success'] ) || empty( $response['data']['engine'] ) ) {
+			return self::sendResponse( false, empty( $response['message'] ) ? 'Something went wrong.' : esc_html( $response['message'] ) );
+		}
+
+		if ( ! in_array( $response['data']['engine'], array('v3','v4') ) ) {
+			return self::sendResponse( false, 'Wrong migration engine ' . $response['data']['engine'] );
+		}
+
+		return self::sendResponse(
+			true,
+			'',
+			array( 'engine' => $response['data']['engine'] )
+		);
+		
+	}
+
+	/**
+	 * Insta Migrate Request
+	 *
+	 * @param string $api_key api key
+	 * @param string $wlm_slug white label migration slug
+	 *
+	 * @return array
+	 *
+	 */
+	public static function instaMigrateRequest( $api_key, $wlm_slug, $locale = '' ) {
+		if ( empty( $api_key ) ) {
+			return self::sendResponse( false, 'API key is required.' );
+		}
+
+		if ( empty( $wlm_slug )  ) {
+			return self::sendResponse( false, 'White label migration slug is required.' );
+		}
+
+		$locale = empty( $locale ) || ! is_string( $locale ) ?  get_locale(): $locale;
+
+		$locale = sanitize_key( $locale );
+
+		$wlm_slug = sanitize_key( $wlm_slug );
+
+		// e2e flow — tell client-app which flow is resolving the engine.
+		$engine = self::getMigrationEngine( $api_key, 'e2e' );
+
+		if ( ! $engine['success'] ) {
+			return $engine;
+		}
+
+		$engine = $engine['data']['engine'];
+		
+		return $engine === 'v3' ? self::v3MigrationRequest($api_key, $wlm_slug, $locale) : self::v4MigrationRequest($api_key, $wlm_slug, $locale);
+	}
+
+	/**
+	 * Insta Migrate V4 Request. i.e. based on InstaMigrate plugin + AI agent
+	 *
+	 * @param string $api_key api key
+	 * @param string $wlm_slug white label migration slug
+	 * @param string $locale locale
+	 *
+	 * @return array
+	 *
+	 */
+	private static function v4MigrationRequest($api_key, $wlm_slug, $locale = ''){
+		$install = self::installInstaMigrate();
+
+		if ( ! $install['success'] ) {
+			return $install;
+		}
+		
+		$insta_mig_key = self::getInstaMigrateApiKey();
+
+		if ( ! $insta_mig_key['success'] ) {
+			return $insta_mig_key;
+		}
+
+		$param = array(
+			'destination_url'   => self::wp_site_url(),
+			'wp_version'  		=> get_bloginfo( 'version' ),
+			'php_version' 		=> phpversion(),
+			'title'       		=> get_bloginfo( 'name' ),
+			'plugin_api_key' 	=> $insta_mig_key['data']['insta_mig_key'],
+			'locale'			=> $locale,
+		);
+
+		$mig_request = Curl::do_curl( 'migrate-v4/' . $wlm_slug . '/e2e-mig', $param, array(), 'POST', 'v2', $api_key );
+
+		if ( ! empty( $mig_request['success'] ) && ! empty( $mig_request['data']['migration_url'] ) ) {
+			return self::sendResponse( 
+				true, 
+				'Migration requested with destination site details. Please visit given url and connect source site to continue migrate site.',
+				array(
+					'migration_url' => $mig_request['data']['migration_url']
+				)
+			);
+		}
+
+		return self::sendResponse( false, empty( $mig_request['message'] ) ? 'Something went wrong.': esc_html( $mig_request['message'] ) );
+	}
+
+	/**
+	 * Insta Migrate V3 Request. i.e. based on InstaWP Connect plugin
+	 *
+	 * @param string $api_key api key
+	 * @param string $wlm_slug white label migration slug
+	 * @param string $locale locale
+	 *
+	 * @return array
+	 *
+	 */
+	private static function v3MigrationRequest($api_key, $wlm_slug, $locale = ''){
+		$install = self::installInstaWPConnect();
+
+		if ( ! $install['success'] ) {
+			return $install;
+		}
+		
+		$generate_api_key = self::generate_api_key( 
+			$api_key, 
+			'',  
+			array(
+				'e2e_mig_push_request' => true,
+				'wlm_slug'             => $wlm_slug,
+				'managed'              => false,
+				'locale'			   => $locale,
+			)
+		);
+
+		if ( ! $generate_api_key ) {
+			delete_option( 'instawp_api_options' );
+			return self::sendResponse( false, 'Failed to connect site.' );
+		}
+
+		return self::sendResponse( 
+			true, 
+			'Migration requested with destination site details. Please visit given url and connect source site to continue migrate site.',
+			array(
+				'migration_url' => Helper::get_migration_url(),
+			)
+		);
+	}
+
+	/**
+	 * Send Response
+	 */
+	public static function sendResponse( $success = true, $message = '', $data = array() ) {
+		return array(
+			'success' 	=> $success,
+			'message' 	=> $message,
+			'data'		=> $data
+		);
+	}
+
+	/**
+	 * Install instamigrate plugin
+	 */
+	public static function installInstaMigrate( $retry = false ) {
+		try {
+	
+			if ( class_exists( '\InstaMigrate' ) ) {
+				return self::sendResponse();
+			}
+
+			if ( ! function_exists( 'get_plugins' ) || ! function_exists( 'get_mu_plugins' ) ) {
+				if ( file_exists( ABSPATH . 'wp-admin/includes/plugin.php' ) ) {
+					require_once ABSPATH . 'wp-admin/includes/plugin.php';
+				}
+			}
+
+			if ( ! function_exists( 'is_plugin_active' ) ) {
+				return self::sendResponse( false, 'Plugin methods not loaded. Failed to install the InstaMigrate plugin.' );
+			}
+
+			// Check if plugin is active
+			if ( ! is_plugin_active( 'instamigrate/insta-migrate.php' ) ) {
+				$params    = array(
+					array(
+						'slug'     => 'instamigrate',
+						'type'     => 'plugin',
+						'activate' => true,
+					),
+				);
+				// Install and active plugin
+				$installer = new Installer( $params );
+				$response  = $installer->start();
+
+				if ( $response[0]['success'] ) {
+					if ( class_exists( '\InstaMigrate' ) && defined('INSTA_MIGRATE_OPTION_KEY') ) {
+						return self::sendResponse();
+					} else {
+						return self::sendResponse( false, 'After install INSTA_MIGRATE_OPTION_KEY not defined.' );
+					}
+				} else {
+					if ( ! $retry ) {
+						return self::installInstaMigrate( true );
+					}
+					$message = $response[0]['message'] ? $response[0]['message'] : 'Failed to install or activate the InstaMigrate plugin.';
+					return self::sendResponse( false, $message );
+				}
+			}
+
+			return self::sendResponse();
+		} catch (\Throwable $th) {
+			return self::sendResponse( false, $th->getMessage() );
+		}
+	}
+
+	/**
+	 * Install instamigrate plugin
+	 */
+	public static function installInstaWPConnect( $retry = false ) {
+		try {
+	
+			if ( class_exists( '\instaWP' ) ) {
+				return self::sendResponse();
+			}
+
+			if ( ! function_exists( 'get_plugins' ) || ! function_exists( 'get_mu_plugins' ) ) {
+				if ( file_exists( ABSPATH . 'wp-admin/includes/plugin.php' ) ) {
+					require_once ABSPATH . 'wp-admin/includes/plugin.php';
+				}
+			}
+
+			if ( ! function_exists( 'is_plugin_active' ) ) {
+				return self::sendResponse( false, 'Plugin methods not loaded. Failed to install the InstaMigrate plugin.' );
+			}
+
+			// Check if plugin is active
+			if ( ! is_plugin_active( 'instawp-connect/instawp-connect.php' ) ) {
+				$params    = array(
+					array(
+						'slug'     => 'instawp-connect',
+						'type'     => 'plugin',
+						'activate' => true,
+					),
+				);
+				// Install and active plugin
+				$installer = new Installer( $params );
+				$response  = $installer->start();
+
+				if ( $response[0]['success'] ) {
+					if ( class_exists( '\instaWP' ) && defined('INSTAWP_PLUGIN_VERSION') ) {
+						return self::sendResponse();
+					} else {
+						return self::sendResponse( false, 'After install INSTAWP_PLUGIN_VERSION not defined.' );
+					}
+				} else {
+					if ( ! $retry ) {
+						return self::installInstaWPConnect( true );
+					}
+					$message = $response[0]['message'] ? $response[0]['message'] : 'Failed to install or activate the InstaWP Connect plugin.';
+					return self::sendResponse( false, $message );
+				}
+			}
+
+			return self::sendResponse();
+		} catch (\Throwable $th) {
+			return self::sendResponse( false, $th->getMessage() );
+		}
+	}
+
+	// Get insta migrate plugin api key
+	public static function getInstaMigrateApiKey() {
+		// Added a leading \ to force global namespace resolution on both the guard
+        if ( ! class_exists('\InstaMigrate') || ! defined('INSTA_MIGRATE_OPTION_KEY') ) {
+			return self::sendResponse( false, 'InstaMigrate plugin is not installed or activated' );
+        }
+
+		$plugin = \InstaMigrate::instance();
+        $plugin->ensure_api_key(); // idempotent: generates only if missing
+
+        $insta_mig_key = is_multisite()
+            ? get_site_option(INSTA_MIGRATE_OPTION_KEY)
+            : get_option(INSTA_MIGRATE_OPTION_KEY);
+
+		if ( empty( $insta_mig_key ) ) {
+			return self::sendResponse( false, 'Failed to generate plugin API key.' );
+		}
+		return self::sendResponse( true, '', [
+			'insta_mig_key' => $insta_mig_key
+		] );
+    }
+
+	/**
 	 * Get InstaWP User Agent
 	 *
 	 * @param null|array|string $agentIdentifier
@@ -167,12 +472,19 @@ class Helper {
 				if ( ! empty( $config['e2e_mig_push_request'] ) || ! empty( $config['wlm_slug'] ) ) {
 					$mig_request = Curl::do_curl( 'migrates-v3/' . $config['wlm_slug'] . '/e2e-push-request', $connect_body, array(), 'POST', 'v2' );
 
-					if ( ! empty( $mig_request['success'] ) && ! empty( $mig_request['data']['group_uuid'] ) ) {
-						self::set_mig_gid( $mig_request['data']['group_uuid'] );
-						return true;
+					if ( empty( $mig_request['success'] ) ) {
+						return false;
 					}
 
-					return false;
+					if ( ! empty( $mig_request['data']['migration_url'] ) ) {
+						self::set_migration_url( $mig_request['data']['migration_url'] );
+					}
+					
+					if ( ! empty( $mig_request['data']['group_uuid'] ) ) {
+						self::set_mig_gid( $mig_request['data']['group_uuid'] );
+					}
+						
+					return true;
 				}
 			}
 
@@ -526,6 +838,16 @@ class Helper {
 		return self::set_settings( $api_options );
 	}
 
+	
+	/**
+	 * Set migration url
+	 */
+	public static function set_migration_url( $url ) {
+		$api_options               = self::get_options();
+		$api_options['migration_url'] = $url;
+		return self::set_settings( $api_options );
+	}
+
 	/**
 	 * Set migration group id
 	 */
@@ -534,6 +856,15 @@ class Helper {
 		$api_options['group_uuid'] = $group_uuid;
 
 		return self::set_settings( $api_options );
+	}
+
+	/**
+	 * Get migration url
+	 */
+	public static function get_migration_url() {
+		$api_options = self::get_options();
+
+		return self::get_args_option( 'migration_url', $api_options );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes PHP warnings during two-way sync plugin/theme actions, bumps the plugin to **0.1.3.4**, and includes the vendored connect-helpers **v1.1.2** (migration engine detection / v3-v4 routing).

## Bug fix — sync action responses

`includes/sync/class-instawp-sync-plugin-theme.php` read the results of `activate_item()`, `deactivate_item()` and `uninstall_item()` via the old numeric `[0]` index. The connect-helpers `Activator`/`Deactivator`/`Uninstaller` classes now return results **keyed by asset slug**, so `[0]` was undefined and `$response` became `null` — producing:

```
PHP Warning: Undefined array key 0 ... line 554
PHP Warning: Trying to access array offset on null ... lines 556, 557
PHP Warning: Undefined array key "success" ... line 579
PHP Warning: Undefined array key "message" ... line 580
```

Changes:
- Added a `get_item_response()` normalizer that resolves the asset-keyed result (with numeric/whole-response fallbacks).
- Routed all 5 asset-keyed call sites (activate/deactivate/uninstall for plugin + theme) through it, with warning-safe `empty()` / `??` reads.
- Fixed `deactivate_item()` to pass the expected `['asset' => ..., 'type' => 'plugin']` structure — previously it passed a bare string, so **deactivation never actually ran** (Deactivator returned "Required parameters are missing!").
- `install_item()` call sites are intentionally left on `[0]` — `Installer::start()` keys results numerically, so they are correct.

## Version / changelog

- `Version` + `INSTAWP_PLUGIN_VERSION` → `0.1.3.4`
- `readme.txt`: `Tested up to: 7.0`, `Stable tag: 0.1.3.4`, new changelog entry.

## Included vendored dependency

- connect-helpers bumped to **v1.1.2**: migration engine detection (`getMigrationEngine`) and unified `instaMigrateRequest()` routing between the v3 (InstaWP Connect) and v4 (InstaMigrate) flows.

## Testing

- `php -l` passes on the modified file.
- Bug fix verified by static analysis against the connect-helpers return shapes; not yet exercised against a live sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)