### PR TITLE
Frill #103: Add 'Clear all' for 2-way sync events

### DIFF
--- a/admin/js/instawp-change-event.js
+++ b/admin/js/instawp-change-event.js
@@ -152,6 +152,22 @@ jQuery(document).ready(function ($) {
         }
     });
 
+    $(document).on('click', '#instawp-clear-all-events', function () {
+        if (confirm('This will remove all sync events. Continue?')) {
+            let formData = new FormData();
+            let site_id = $("#staging-site-sync").val();
+            formData.append('site_id', site_id);
+            formData.append('action', 'instawp_clear_all_events');
+            baseCall(formData, () => {
+                get_site_events();
+                display_event_action_dropdown();
+                $("body").find('#select-all-event').prop('checked', false);
+            }, (message) => {
+                alert(message);
+            });
+        }
+    });
+
     $(document).on('click', '.instawp-refresh-events', function () {
         get_site_events();
     });

--- a/includes/sync/class-instawp-sync-ajax.php
+++ b/includes/sync/class-instawp-sync-ajax.php
@@ -32,6 +32,7 @@ class InstaWP_Sync_Ajax {
 		add_action( 'wp_ajax_instawp_sync_changes', array( $this, 'sync_changes' ) );
 		add_action( 'wp_ajax_instawp_get_events_summary', array( $this, 'get_events_summary' ) );
 		add_action( 'wp_ajax_instawp_delete_events', array( $this, 'delete_events' ) );
+		add_action( 'wp_ajax_instawp_clear_all_events', array( $this, 'clear_all_events' ) );
 		add_action( 'wp_ajax_instawp_calculate_events', array( $this, 'calculate_events' ) );
 	}
 
@@ -428,6 +429,25 @@ class InstaWP_Sync_Ajax {
 
 			$this->send_success( 'Data deleted' );
 		}
+	}
+
+	/**
+	 * Delete ALL sync events for this site in one action.
+	 *
+	 * Clears every row from the events table (and its per-destination
+	 * sync-status table) that `delete_events()` operates on, regardless of
+	 * pagination or current selection. Uses the same nonce + capability
+	 * checks as `delete_events()`.
+	 */
+	public function clear_all_events() {
+		InstaWP_Tools::verify_ajax_request( InstaWP_Setting::get_allowed_role() );
+
+		global $wpdb;
+
+		$wpdb->query( 'TRUNCATE TABLE ' . INSTAWP_DB_TABLE_EVENTS ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( 'TRUNCATE TABLE ' . INSTAWP_DB_TABLE_EVENT_SITES ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		$this->send_success( 'All events cleared' );
 	}
 
 	public function calculate_events() {

--- a/migrate/templates/part-sync.php
+++ b/migrate/templates/part-sync.php
@@ -101,6 +101,9 @@ $events         = $syncing_status ? InstaWP_Sync_DB::total_events() : array();
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"/>
                             </svg>
                         </button>
+                        <button type="button" id="instawp-clear-all-events" class="bg-white hover:bg-red-100 text-red-400 py-2 px-3 border border-red-400 rounded shadow font-medium text-sm">
+                            <?php esc_html_e( 'Clear all', 'instawp-connect' ); ?>
+                        </button>
                     </div>
                 </div>
                 <div class="mt-8 flow-root">


### PR DESCRIPTION
## Frill #103 — "Clear all" for 2-way sync events (5 votes)

- Roadmap idea: https://feedback.instawp.com/ideas/enable-removing-events-from-2way-sync
- ClickUp: https://app.clickup.com/t/86d3c7gz7

### Problem
The 2-way sync screen lets users select + delete events, but **select-all only covers the current page** and the list is paginated — there was no one-click way to clear the whole list to tidy up.

### Change (mirrors the existing `delete_events` flow exactly)
- **`migrate/templates/part-sync.php`** — adds a "Clear all" button next to the delete-selected button (same styling; not gated on a selection).
- **`admin/js/instawp-change-event.js`** — click handler with a confirm ("This will remove all sync events. Continue?"), POSTs `action=instawp_clear_all_events` via the existing `baseCall()` helper (auto-appends the same `security` nonce); refreshes the list + resets controls on success.
- **`includes/sync/class-instawp-sync-ajax.php`** — registers `wp_ajax_instawp_clear_all_events` next to `instawp_delete_events`; new `clear_all_events()` runs the same `verify_ajax_request( get_allowed_role() )` guard (nonce + capability), then truncates the two event tables `delete_events()` operates on (`INSTAWP_DB_TABLE_EVENTS`, `INSTAWP_DB_TABLE_EVENT_SITES`) — same tables the existing `instawp_delete_sync_entries()` helper clears.

### QA steps
1. Generate **>1 page** of sync events (create/update several posts, install plugins, etc.).
2. Confirm the **Clear all** button shows next to the trash button; list is paginated.
3. Click **Clear all** → confirm dialog → **Cancel** changes nothing.
4. Click **Clear all** → confirm → list empties **across all pages** (pagination disappears); reload confirms it persists (DB truncated).
5. Security: a non-admin / logged-out POST to `instawp_clear_all_events` is rejected (nonce + capability), same as delete.

### Notes
- `php -l` clean. JS is enqueued directly (no build step). Recommend `/code-review ultra <PR#>` after open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
