### PR TITLE
Frill #145: Show InstaWP menu only to selected users (whitelist)

### DIFF
--- a/admin/class-instawp-admin.php
+++ b/admin/class-instawp-admin.php
@@ -142,8 +142,8 @@ class InstaWP_Admin {
 			return;
 		}
 
-		$selected_users = Option::get_option( 'instawp_hide_plugin_to_users' );
-		if ( ! empty( $selected_users ) && is_array( $selected_users ) && in_array( get_current_user_id(), $selected_users ) ) {
+		// Respects show-list (whitelist) precedence over hide-list (blacklist). See InstaWP_Setting::can_user_see_menu().
+		if ( ! InstaWP_Setting::can_user_see_menu() ) {
 			return;
 		}
 

--- a/includes/class-instawp-hooks.php
+++ b/includes/class-instawp-hooks.php
@@ -455,10 +455,8 @@ if ( ! class_exists( 'InstaWP_Hooks' ) ) {
 			}
 
 			if ( $can_show ) {
-				$selected_users = Option::get_option( 'instawp_hide_plugin_to_users' );
-				if ( ! empty( $selected_users ) && is_array( $selected_users ) && in_array( get_current_user_id(), $selected_users ) ) {
-					$can_show = false;
-				}
+				// Respects show-list (whitelist) precedence over hide-list (blacklist). See InstaWP_Setting::can_user_see_menu().
+				$can_show = InstaWP_Setting::can_user_see_menu( $current_user->ID );
 			}
 
 			return $can_show;
@@ -615,9 +613,9 @@ if ( ! class_exists( 'InstaWP_Hooks' ) ) {
 		}
 
 		public function remove_edge_cache_submenu( $can_show, $current_user ) {
-			$selected_users = Option::get_option( 'instawp_hide_plugin_to_users' );
-			if ( ! empty( $selected_users ) && is_array( $selected_users ) ) {
-				$can_show = ! in_array( $current_user->ID, $selected_users );
+			// Respects show-list (whitelist) precedence over hide-list (blacklist). See InstaWP_Setting::can_user_see_menu().
+			if ( $can_show ) {
+				$can_show = InstaWP_Setting::can_user_see_menu( $current_user->ID );
 			}
 
 			return $can_show;

--- a/includes/class-instawp-setting.php
+++ b/includes/class-instawp-setting.php
@@ -104,6 +104,45 @@ class InstaWP_Setting {
 		return $allowed_role;
 	}
 
+	/**
+	 * Determine whether a given user is allowed to see the InstaWP menu / topbar icon.
+	 *
+	 * Precedence (highest to lowest):
+	 * 1. Show-list (whitelist) is non-empty  -> visible ONLY to users in the list, hidden for everyone else.
+	 *    When the whitelist is in use, the hide-list is ignored (the whitelist is the explicit, stricter rule).
+	 * 2. Hide-list (blacklist) is non-empty   -> hidden only for the listed users (existing behavior).
+	 * 3. Neither list configured              -> visible (default; role gating is handled separately by the caller).
+	 *
+	 * Role-based visibility (get_allowed_role / sync_tab_roles) is enforced by the caller and is intentionally
+	 * not duplicated here, so this method only decides the per-user list precedence.
+	 *
+	 * @param int $user_id User ID to evaluate. Defaults to the current user.
+	 *
+	 * @return bool True if the user should see the InstaWP menu / icon.
+	 */
+	public static function can_user_see_menu( $user_id = 0 ) {
+		$user_id = $user_id ? (int) $user_id : get_current_user_id();
+
+		$show_users = Option::get_option( 'instawp_show_plugin_to_users' );
+		$show_users = ! empty( $show_users ) && is_array( $show_users ) ? array_map( 'intval', $show_users ) : array();
+
+		// Whitelist active: only listed users may see the menu.
+		if ( ! empty( $show_users ) ) {
+			return in_array( $user_id, $show_users, true );
+		}
+
+		$hide_users = Option::get_option( 'instawp_hide_plugin_to_users' );
+		$hide_users = ! empty( $hide_users ) && is_array( $hide_users ) ? array_map( 'intval', $hide_users ) : array();
+
+		// Blacklist active: hide the menu only for listed users.
+		if ( ! empty( $hide_users ) ) {
+			return ! in_array( $user_id, $hide_users, true );
+		}
+
+		// Default: visible.
+		return true;
+	}
+
 	public static function generate_section_field( $field = array() ) {
 		$field_id            = self::get_args_option( 'id', $field );
 		$field_name          = self::get_args_option( 'name', $field );
@@ -353,7 +392,19 @@ class InstaWP_Setting {
 					'action'   => 'instawp_handle_select2',
 					'event'    => 'instawp_get_users_exclude_current',
 					'title'    => class_exists( '\Edge_Cache_Plugin' ) ? esc_html__( 'Hide InstaWP Menu & Edge Cache to Users', 'instawp-connect' ) : esc_html__( 'Hide InstaWP Menu to Users', 'instawp-connect' ),
+					'tooltip'  => esc_html__( 'Hide the InstaWP menu from the selected users. Ignored when "Show InstaWP Menu only to selected users" has any users selected.', 'instawp-connect' ),
 					'options'  => self::get_select2_default_selected_option( 'instawp_hide_plugin_to_users' ),
+				),
+				array(
+					'id'       => 'instawp_show_plugin_to_users',
+					'type'     => 'select2',
+					'remote'   => true,
+					'multiple' => true,
+					'action'   => 'instawp_handle_select2',
+					'event'    => 'instawp_get_users',
+					'title'    => esc_html__( 'Show InstaWP Menu only to selected users', 'instawp-connect' ),
+					'tooltip'  => esc_html__( 'When one or more users are selected, the InstaWP menu and topbar icon are shown ONLY to those users and hidden from everyone else (subject to the allowed role). Takes precedence over "Hide InstaWP Menu to Users". Leave empty to keep the default behavior.', 'instawp-connect' ),
+					'options'  => self::get_select2_default_selected_option( 'instawp_show_plugin_to_users' ),
 				),
 				array(
 					'id'      => 'instawp_cdn_auto_purge',
@@ -742,7 +793,7 @@ class InstaWP_Setting {
 			}
 
 			return $role_options;
-		} elseif ( $option === 'instawp_hide_plugin_to_users' ) {
+		} elseif ( $option === 'instawp_hide_plugin_to_users' || $option === 'instawp_show_plugin_to_users' ) {
 			$users_data     = array();
 			$selected_users = Option::get_option( $option );
 			$selected_users = ! empty( $selected_users ) ? $selected_users : array();

--- a/migrate/class-instawp-migrate.php
+++ b/migrate/class-instawp-migrate.php
@@ -76,6 +76,7 @@ if ( ! class_exists( 'InstaWP_Migration' ) ) {
 				$form_data,
 				array(
 					'instawp_hide_plugin_to_users' => array(),
+					'instawp_show_plugin_to_users' => array(),
 					'instawp_sync_tab_roles'       => array(),
 				)
 			);


### PR DESCRIPTION
## Frill #145 — Show InstaWP menu only to selected users (whitelist) (4 votes)

- Roadmap idea: https://feedback.instawp.com/ideas/instawp-connect-plugin-option-to-show-instawp-menu-to-selected-users
- ClickUp: https://app.clickup.com/t/86d3c7gzx

### Problem
The plugin could only **HIDE** the InstaWP menu for selected users (a blacklist). By default the menu shows to everyone with the allowed role, so any **new admin automatically gets staging-creation access**. Requester wanted the inverse: a whitelist so the menu shows **only** to selected users.

### Change (backward-compatible; mirrors the existing hide setting)
- New setting **`instawp_show_plugin_to_users`** — "Show InstaWP Menu only to selected users" (select2, remote user search), declared next to the existing hide field in `class-instawp-setting.php`.
- New centralized helper **`InstaWP_Setting::can_user_see_menu($user_id)`** with explicit precedence:
  1. **Show-list non-empty** → visible only to listed users (hide-list ignored).
  2. **Hide-list non-empty** → existing behavior (hidden for listed users).
  3. **Neither set** → default visible (role gating unchanged, handled by callers).
- Both enforcement points routed through the helper — admin menu (`admin/class-instawp-admin.php`) and topbar icon + edge-cache submenu (`includes/class-instawp-hooks.php`). The edge-cache path now only ever **narrows** visibility (small consistency fix).
- New key added to the WaaS settings-reset defaults (`migrate/class-instawp-migrate.php`).

### QA steps
1. Settings → set "Show InstaWP Menu only to selected users" to **User A** → save.
2. As **User A**: InstaWP menu + topbar icon visible.
3. As a different admin **User B** (not listed): menu + icon **not** visible.
4. Add **User B** to the hide-list too (keep show-list set) → B still hidden, A still visible (whitelist precedence).
5. Clear show-list, keep B in hide-list → reverts to original hide behavior.
6. Clear both → default: visible to all allowed-role admins.

### Notes
- All four files `php -l` clean. Recommend `/code-review ultra <PR#>` after open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
