### PR TITLE
ci: run Claude Code Review on Opus

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -104,4 +104,4 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model opus --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
Pin the automated PR review workflow (`claude-code-action@v1`) to the **Opus** model via the `opus` alias, so it always resolves to the latest Opus instead of defaulting to Sonnet.

Only `.github/workflows/claude-code-review.yml` changes — adds `--model opus` to `claude_args`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)