### PR TITLE
chore: composer dep update (phpseclib 3.0.55) + 0.1.3.4 release date

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -100,7 +100,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 = 0.1.3.4 - Beta =
 - Added: Migration engine detection — end-to-end migrations now auto-route to the v3 or v4 (InstaMigrate) flow.
-- Fixed: Two-way sync no longer emits PHP warnings and now correctly reports plugin/theme activate, deactivate, and delete results.
+- Fixed: Two-way sync no PHP warnings.
 - Updated: Dependency packages.
 
 = 0.1.3.3 - 19 May 2026 =

--- a/readme.txt
+++ b/readme.txt
@@ -98,7 +98,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
-= 0.1.3.4 - Beta =
+= 0.1.3.4 - 17-06-2026 =
 - Added: Migration engine detection — end-to-end migrations now auto-route to the v3 or v4 (InstaMigrate) flow.
 - Fixed: Two-way sync no PHP warnings.
 - Updated: Dependency packages.

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -177,17 +177,17 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.52",
-            "version_normalized": "3.0.52.0",
+            "version": "3.0.55",
+            "version_normalized": "3.0.55.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce"
+                "reference": "db9744e6d47e742b1f974e965ad49bdd041105af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/2adaefc83df2ec548558307690f376dd7d4f4fce",
-                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/db9744e6d47e742b1f974e965ad49bdd041105af",
+                "reference": "db9744e6d47e742b1f974e965ad49bdd041105af",
                 "shasum": ""
             },
             "require": {
@@ -205,7 +205,7 @@
                 "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
                 "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
             },
-            "time": "2026-04-27T07:02:15+00:00",
+            "time": "2026-06-14T23:24:10+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -270,7 +270,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.52"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.55"
             },
             "funding": [
                 {

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -49,9 +49,9 @@
             'dev_requirement' => false,
         ),
         'phpseclib/phpseclib' => array(
-            'pretty_version' => '3.0.52',
-            'version' => '3.0.52.0',
-            'reference' => '2adaefc83df2ec548558307690f376dd7d4f4fce',
+            'pretty_version' => '3.0.55',
+            'version' => '3.0.55.0',
+            'reference' => 'db9744e6d47e742b1f974e965ad49bdd041105af',
             'type' => 'library',
             'install_path' => __DIR__ . '/../phpseclib/phpseclib',
             'aliases' => array(),

--- a/vendor/phpseclib/phpseclib/README.md
+++ b/vendor/phpseclib/phpseclib/README.md
@@ -29,6 +29,17 @@ SSH-2, SFTP, X.509, an arbitrary-precision integer arithmetic library, Ed25519 /
 * Unstable API
 * Do not use in production
 
+### 4.0
+
+* Expected Release Date: September 2026
+* Long term support (LTS) release
+* X509 split into separate X509, CRL, CSR and SPKAC classes
+* PFX and CMS classes added
+* All ASN1 classes are lazy loaded by default
+* Minimum PHP version: 8.1.0
+* PSR-4 autoloading with namespace rooted at `\phpseclib4`
+* Install via Composer: `composer require phpseclib/phpseclib:4.0.x-dev`
+
 ### 3.0
 
 * Long term support (LTS) release
@@ -51,7 +62,7 @@ SSH-2, SFTP, X.509, an arbitrary-precision integer arithmetic library, Ed25519 /
 * PHP4 compatible
 * Composer compatible (PSR-0 autoloading)
 * Install using Composer: `composer require phpseclib/phpseclib:~1.0`
-* [Download 1.0.25 as ZIP](http://sourceforge.net/projects/phpseclib/files/phpseclib1.0.25.zip/download)
+* [Download 1.0.25 as ZIP](http://sourceforge.net/projects/phpseclib/files/phpseclib1.0.30.zip/download)
 
 ## Security contact information
 

--- a/vendor/phpseclib/phpseclib/phpseclib/Crypt/DES.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Crypt/DES.php
@@ -1292,14 +1292,14 @@ class DES extends BlockCipher
 
         $init_crypt = 'static $sbox1, $sbox2, $sbox3, $sbox4, $sbox5, $sbox6, $sbox7, $sbox8, $shuffleip, $shuffleinvip;
             if (!$sbox1) {
-                $sbox1 = array_map("self::safe_intval", self::$sbox1);
-                $sbox2 = array_map("self::safe_intval", self::$sbox2);
-                $sbox3 = array_map("self::safe_intval", self::$sbox3);
-                $sbox4 = array_map("self::safe_intval", self::$sbox4);
-                $sbox5 = array_map("self::safe_intval", self::$sbox5);
-                $sbox6 = array_map("self::safe_intval", self::$sbox6);
-                $sbox7 = array_map("self::safe_intval", self::$sbox7);
-                $sbox8 = array_map("self::safe_intval", self::$sbox8);'
+                $sbox1 = array_map(["' . self::class . '", "safe_intval"], self::$sbox1);
+                $sbox2 = array_map(["' . self::class . '", "safe_intval"], self::$sbox2);
+                $sbox3 = array_map(["' . self::class . '", "safe_intval"], self::$sbox3);
+                $sbox4 = array_map(["' . self::class  .'", "safe_intval"], self::$sbox4);
+                $sbox5 = array_map(["' . self::class . '", "safe_intval"], self::$sbox5);
+                $sbox6 = array_map(["' . self::class . '", "safe_intval"], self::$sbox6);
+                $sbox7 = array_map(["' . self::class . '", "safe_intval"], self::$sbox7);
+                $sbox8 = array_map(["' . self::class . '", "safe_intval"], self::$sbox8);'
                 /* Merge $shuffle with $[inv]ipmap */ . '
                 for ($i = 0; $i < 256; ++$i) {
                     $shuffleip[]    =  self::$shuffle[self::$ipmap[$i]];

--- a/vendor/phpseclib/phpseclib/phpseclib/Crypt/DSA/Formats/Keys/PKCS1.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Crypt/DSA/Formats/Keys/PKCS1.php
@@ -63,6 +63,9 @@ abstract class PKCS1 extends Progenitor
 
         $key = ASN1::asn1map($decoded[0], Maps\DSAPrivateKey::MAP);
         if (is_array($key)) {
+            if ($key['version']->toString() !== '0') {
+                throw new \UnexpectedValueException('Version number is not valid');
+            }
             return $key;
         }
 

--- a/vendor/phpseclib/phpseclib/phpseclib/Crypt/DSA/PrivateKey.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Crypt/DSA/PrivateKey.php
@@ -91,7 +91,7 @@ final class PrivateKey extends DSA implements Common\PrivateKey
         if (function_exists('openssl_get_md_methods') && self::$forcedEngine !== 'PHP') {
             if (in_array($this->hash->getHash(), openssl_get_md_methods())) {
                 $signature = '';
-                $result = openssl_sign($message, $signature, $this->toString('PKCS8'), $this->hash->getHash());
+                $result = openssl_sign($message, $signature, $this->withPassword()->toString('PKCS8'), $this->hash->getHash());
 
                 if ($result) {
                     if ($this->shortFormat == 'ASN1') {

--- a/vendor/phpseclib/phpseclib/phpseclib/Crypt/EC.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Crypt/EC.php
@@ -180,6 +180,7 @@ abstract class EC extends AsymmetricKey
                     // OPENSSL_KEYTYPE_X25519 introduced in PHP 8.4.0
                     'OpenSSL'   => defined('OPENSSL_KEYTYPE_X25519'),
                 ];
+                break;
             // OPENSSL_KEYTYPE_X448 introduced in PHP 8.4.0
             case 'Curve448':
                 $providers = ['OpenSSL' => defined('OPENSSL_KEYTYPE_X448')];

--- a/vendor/phpseclib/phpseclib/phpseclib/Crypt/RSA.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Crypt/RSA.php
@@ -976,6 +976,43 @@ abstract class RSA extends AsymmetricKey
                         $error = 'Engine OpenSSL is forced but can\'t be used because the salt length doesn\'t match the hash length';
                 }
             }
+            /*
+            https://datatracker.ietf.org/doc/html/rfc4055#page-6 says the following:
+
+               There are two possible encodings for the AlgorithmIdentifier
+               parameters field associated with these object identifiers.  The two
+               alternatives arise from the loss of the OPTIONAL associated with the
+               algorithm identifier parameters when the 1988 syntax for
+               AlgorithmIdentifier was translated into the 1997 syntax.  Later the
+               OPTIONAL was recovered via a defect report, but by then many people
+               thought that algorithm parameters were mandatory.  Because of this
+               history some implementations encode parameters as a NULL element
+               while others omit them entirely.  The correct encoding is to omit the
+               parameters field; however, when RSASSA-PSS and RSAES-OAEP were
+               defined, it was done using the NULL parameters rather than absent
+               parameters.
+
+               All implementations MUST accept both NULL and absent parameters as
+               legal and equivalent encodings.
+
+            OpenSSL does NOT accept both - it REQUIRES NULL be present. phpseclib, however,
+            DOES accept both. at first, it didn't. at first, not knowing why some small number
+            of PKCS1 signatures omitted NULL, i added the SIGNATURE_RELAXED_PKCS1 mode on
+            2015-08-26. https://phpseclib.com/docs/rsa#rsasignature_relaxed_pkcs1 talks more
+            about that mode. later, on 2021-04-05, there was CVE-2021-30130. consequently,
+            the SIGNATURE_PKCS1 mode was updated to accept either NULL or non-NULL.
+
+            because phpseclib accepts PKCS1 signatures that OpenSSL doesn't, OpenSSL isn't
+            used for PKCS1. if the OpenSSL extension is installed then it'll be used to perform
+            unpadded RSA (ie. modular exponentiation), however, the actual PKCS1 construction
+            takes place in PHP code vs OpenSSL.
+
+            see https://security.stackexchange.com/questions/110330/encoding-of-optional-null-in-der
+            for an additional reference
+            */
+            if ($this->$paddingType === self::SIGNATURE_PKCS1 && $func === 'openssl_verify') {
+                $error = 'Engine OpenSSL is forced but can\'t be used with PKCS1 signature verification because OpenSSL requires NULL be present whereas phpseclib doesn\'t';
+            }
             if ($this->$paddingType === self::ENCRYPTION_OAEP) {
                 switch (true) {
                     case $this->hash->getHash() !== $this->mgfHash->getHash():
@@ -1037,7 +1074,9 @@ abstract class RSA extends AsymmetricKey
                 }
             } else {
                 if ($this->encryptionPadding !== self::ENCRYPTION_OAEP || PHP_VERSION_ID >= 80500) {
-                    $key = $this->toString('PKCS8');
+                    $key = $this instanceof PrivateKey ?
+                        $this->withPassword()->toString('PKCS8') :
+                        $this->toString('PKCS8');
                     if ($func === 'openssl_private_decrypt' && strpos($key, 'PUBLIC') !== false) {
                         if ($this->encryptionPadding === self::ENCRYPTION_OAEP) {
                             if (self::$forcedEngine === 'OpenSSL') {
@@ -1077,7 +1116,21 @@ abstract class RSA extends AsymmetricKey
                         case self::ENCRYPTION_NONE:
                         case self::ENCRYPTION_PKCS1:
                             $padding = $this->encryptionPadding === self::ENCRYPTION_NONE ? OPENSSL_NO_PADDING : OPENSSL_PKCS1_PADDING;
-                            $result = $func($message, $output, $key, $padding);
+                            // on github actions, php 7.0 and 7.1 on windows emit the following warning:
+                            // openssl_private_decrypt(): key parameter is not a valid private key
+                            set_error_handler(function ($errno, $errstr) {
+                                throw new BadConfigurationException("Engine OpenSSL is forced but got error: $errstr");
+                            });
+                            try {
+                                $result = $func($message, $output, $key, $padding);
+                            } catch (BadConfigurationException $e) {
+                                if (self::$forcedEngine === 'OpenSSL') {
+                                    throw $e;
+                                }
+                                $result = false;
+                            } finally {
+                                restore_error_handler();
+                            }
                             break;
                         //case self::ENCRYPTION_OAEP:
                         default:

--- a/vendor/phpseclib/phpseclib/phpseclib/Crypt/RSA/Formats/Keys/PKCS1.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Crypt/RSA/Formats/Keys/PKCS1.php
@@ -65,6 +65,9 @@ abstract class PKCS1 extends Progenitor
 
         $key = ASN1::asn1map($decoded[0], Maps\RSAPrivateKey::MAP);
         if (is_array($key)) {
+            if ($key['version'] === false) {
+                throw new \UnexpectedValueException('Version number is not valid');
+            }
             $components += [
                 'modulus' => $key['modulus'],
                 'publicExponent' => $key['publicExponent'],

--- a/vendor/phpseclib/phpseclib/phpseclib/Crypt/RSA/PublicKey.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Crypt/RSA/PublicKey.php
@@ -302,44 +302,6 @@ final class PublicKey extends RSA implements Common\PublicKey
      */
     public function verify($message, $signature)
     {
-        /*
-        https://datatracker.ietf.org/doc/html/rfc4055#page-6 says the following:
-
-           There are two possible encodings for the AlgorithmIdentifier
-           parameters field associated with these object identifiers.  The two
-           alternatives arise from the loss of the OPTIONAL associated with the
-           algorithm identifier parameters when the 1988 syntax for
-           AlgorithmIdentifier was translated into the 1997 syntax.  Later the
-           OPTIONAL was recovered via a defect report, but by then many people
-           thought that algorithm parameters were mandatory.  Because of this
-           history some implementations encode parameters as a NULL element
-           while others omit them entirely.  The correct encoding is to omit the
-           parameters field; however, when RSASSA-PSS and RSAES-OAEP were
-           defined, it was done using the NULL parameters rather than absent
-           parameters.
-
-           All implementations MUST accept both NULL and absent parameters as
-           legal and equivalent encodings.
-
-        OpenSSL does NOT accept both - it REQUIRES NULL be present. phpseclib, however,
-        DOES accept both. at first, it didn't. at first, not knowing why some small number
-        of PKCS1 signatures ommitted NULL, i added the SIGNATURE_RELAXED_PKCS1 mode on
-        2015-08-26. https://phpseclib.com/docs/rsa#rsasignature_relaxed_pkcs1 talks more
-        about that mode. later, on 2021-04-05, there was CVE-2021-30130. consequently,
-        the SIGNATURE_PKCS1 mode was updated to accept either NULL or non-NULL.
-
-        because phpseclib accepts PKCS1 signatures that OpenSSL doesn't, OpenSSL isn't
-        used for PKCS1. if the OpenSSL extension is installed then it'll be used to perform
-        unpadded RSA (ie. modular exponentation), however, the actual PKCS1 construction
-        takes place in PHP code vs OpenSSL.
-
-        see https://security.stackexchange.com/questions/110330/encoding-of-optional-null-in-der
-        for an additional reference
-        */
-        if ($this->signaturePadding === self::SIGNATURE_PKCS1 && isset(self::$forcedEngine) && self::$forcedEngine !== 'PHP') {
-            throw new BadConfigurationException('Engine OpenSSL is forced but unavailable for RSA PKCS1 signature verification');
-        }
-
         $result = $this->handleOpenSSL('openssl_verify', $message, $signature);
         if ($result !== null) {
             return $result;

--- a/vendor/phpseclib/phpseclib/phpseclib/File/ASN1.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/File/ASN1.php
@@ -131,6 +131,8 @@ abstract class ASN1
      */
     private static $encoded;
 
+    private static $use64BitOIDHandling;
+
     /**
      * Type mapping table for the ANY type.
      *
@@ -190,6 +192,7 @@ abstract class ASN1
      *
      * @param Element|string $encoded
      * @return ?array
+     * @changed in phpseclib 4.0.0
      */
     public static function decodeBER($encoded)
     {
@@ -514,6 +517,7 @@ abstract class ASN1
      * @param array $mapping
      * @param array $special
      * @return array|bool|Element|string|null
+     * @changed in phpseclib 4.0.0
      */
     public static function asn1map(array $decoded, $mapping, $special = [])
     {
@@ -840,6 +844,7 @@ abstract class ASN1
      * @param array $mapping
      * @param array $special
      * @return string
+     * @changed in phpseclib 4.0.0
      */
     public static function encodeDER($source, $mapping, $special = [])
     {
@@ -1148,6 +1153,19 @@ abstract class ASN1
         return chr($tag) . self::encodeLength(strlen($value)) . $value;
     }
 
+    public static function enable64BitOIDHandling()
+    {
+        if (PHP_INT_SIZE === 4) {
+            throw new \RuntimeException('64-bit OID handling is unavailable on 32-bit PHP installs');
+        }
+        self::$use64BitOIDHandling = true;
+    }
+
+    public static function disable64BitOIDHandling()
+    {
+        self::$use64BitOIDHandling = false;
+    }
+
     /**
      * BER-decode the OID
      *
@@ -1155,6 +1173,7 @@ abstract class ASN1
      *
      * @param string $content
      * @return string
+     * @changed in phpseclib 4.0.0
      */
     public static function decodeOID($content)
     {
@@ -1163,6 +1182,10 @@ abstract class ASN1
         static $eighty;
         if (!$eighty) {
             $eighty = new BigInteger(80);
+        }
+
+        if (!isset(self::$use64BitOIDHandling)) {
+            self::$use64BitOIDHandling = PHP_INT_SIZE === 8;
         }
 
         $oid = [];
@@ -1179,13 +1202,50 @@ abstract class ASN1
         }
 
         $n = new BigInteger();
-        while ($pos < $len) {
-            $temp = ord($content[$pos++]);
-            $n = $n->bitwise_leftShift(7);
-            $n = $n->bitwise_or(new BigInteger($temp & 0x7F));
-            if (~$temp & 0x80) {
-                $oid[] = $n;
-                $n = new BigInteger();
+        $subn = $numBytes = 0;
+        if (self::$use64BitOIDHandling) {
+            $prefix = '';
+            while ($pos < $len) {
+                $temp = ord($content[$pos++]);
+                $subn <<= 7;
+                $subn |= ($temp & 0x7F);
+                $numBytes++;
+                $endByte = ~$temp & 0x80;
+                if ($numBytes === PHP_INT_SIZE) {
+                    $prefix .= substr(pack('J', $subn), 1); // we're basically left shifting by 7 bytes
+                    $subn = $numBytes = 0;
+                    if ($endByte) {
+                        $oid[] = new BigInteger($prefix, 256);
+                        $prefix = '';
+                    }
+                } elseif ($endByte) {
+                    if (strlen($prefix)) {
+                        $arc = new BigInteger($prefix, 256);
+                        $arc = $arc->bitwise_leftShift($numBytes * 7);
+                        $oid[] = $arc->bitwise_or(new BigInteger($subn));
+                        $prefix = '';
+                    } else {
+                        $oid[] = new BigInteger($subn);
+                    }
+                    $subn = $numBytes = 0;
+                }
+            }
+        } else {
+            while ($pos < $len) {
+                $temp = ord($content[$pos++]);
+                $subn <<= 7;
+                $subn |= ($temp & 0x7F);
+                $numBytes++;
+                $endByte = ~$temp & 0x80;
+                if ($numBytes === PHP_INT_SIZE || $endByte) {
+                    $n = $n->bitwise_leftShift($numBytes * 7);
+                    $n = $n->bitwise_or(new BigInteger($subn));
+                    $subn = $numBytes = 0;
+                    if ($endByte) {
+                        $oid[] = $n;
+                        $n = new BigInteger();
+                    }
+                }
             }
         }
         $part1 = array_shift($oid);
@@ -1272,6 +1332,7 @@ abstract class ASN1
      * @param string $content
      * @param int $tag
      * @return \DateTime|false
+     * @changed in phpseclib 4.0.0
      */
     private static function decodeTime($content, $tag)
     {
@@ -1317,6 +1378,7 @@ abstract class ASN1
      * Sets the time / date format for asn1map().
      *
      * @param string $format
+     * @removed in phpseclib 4.0.0
      */
     public static function setTimeFormat($format)
     {
@@ -1330,6 +1392,7 @@ abstract class ASN1
      * Previously loaded OIDs are retained.
      *
      * @param array $oids
+     * @changed in phpseclib 4.0.0
      */
     public static function loadOIDs(array $oids)
     {
@@ -1344,6 +1407,7 @@ abstract class ASN1
      * Previously loaded filters are not retained.
      *
      * @param array $filters
+     * @removed in phpseclib 4.0.0
      */
     public static function setFilters(array $filters)
     {
@@ -1360,6 +1424,7 @@ abstract class ASN1
      * @param int $from
      * @param int $to
      * @return string
+     * @removed in phpseclib 4.0.0
      */
     public static function convert($in, $from = self::TYPE_UTF8_STRING, $to = self::TYPE_UTF8_STRING)
     {
@@ -1525,6 +1590,7 @@ abstract class ASN1
      *
      * @param string $name
      * @return string
+     * @removed in phpseclib 4.0.0
      */
     public static function getOID($name)
     {

--- a/vendor/phpseclib/phpseclib/phpseclib/File/X509.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/File/X509.php
@@ -270,9 +270,17 @@ class X509
     private $domains = null;
 
     /**
+     * URL fetch callback
+     *
+     * @var string|array|null
+     */
+    private static $urlFetchCallback = null;
+
+    /**
      * Default Constructor.
      *
      * @return X509
+     * @changed in phpseclib 4.0.0
      */
     public function __construct()
     {
@@ -429,6 +437,7 @@ class X509
      * @param array|string $cert
      * @param int $mode
      * @return mixed
+     * @removed in phpseclib 4.0.0
      */
     public function loadX509($cert, $mode = self::FORMAT_AUTO_DETECT)
     {
@@ -502,6 +511,7 @@ class X509
      * @param array $cert
      * @param int $format optional
      * @return string
+     * @removed in phpseclib 4.0.0
      */
     public function saveX509(array $cert, $format = self::FORMAT_PEM)
     {
@@ -959,6 +969,7 @@ class X509
      *
      * @param string $cert
      * @return bool
+     * @removed in phpseclib 4.0.0
      */
     public function loadCA($cert)
     {
@@ -1085,6 +1096,7 @@ class X509
      *
      * @param \DateTimeInterface|string $date optional
      * @return bool
+     * @removed in phpseclib 4.0.0
      */
     public function validateDate($date = null)
     {
@@ -1115,6 +1127,10 @@ class X509
     /**
      * Fetches a URL
      *
+     * If a fetch callback is set via setURLFetchCallback(), the host is resolved
+     * once and the connection is pinned to that IP (the callback judges the
+     * resolved IP, preventing DNS-rebinding bypass).
+     *
      * @param string $url
      * @return bool|string
      */
@@ -1125,25 +1141,58 @@ class X509
         }
 
         $parts = parse_url($url);
+        if ($parts === false || !isset($parts['scheme']) || !isset($parts['host'])) {
+            return false;
+        }
+        $host = $parts['host'];
+        $port = isset($parts['port']) ? $parts['port'] : 80;
+
+        if (isset(self::$urlFetchCallback)) {
+            if (filter_var($host, FILTER_VALIDATE_IP)) {
+                $ip = $host;
+                // unwrap IPv4-mapped IPv6 so the callback judges the real v4 address
+                if (preg_match('/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i', $ip, $m)) {
+                    $ip = $m[1];
+                }
+            } else {
+                $records = dns_get_record($host, DNS_A | DNS_AAAA);
+                if (!$records) {
+                    return false;
+                }
+                if (isset($records[0]['ip'])) {
+                    $ip = $records[0]['ip'];
+                } elseif (isset($records[0]['ipv6'])) {
+                    $ip = $records[0]['ipv6'];
+                } else {
+                    return false;
+                }
+            }
+            if (!call_user_func(self::$urlFetchCallback, $host, $ip, $port, $parts['scheme'])) {
+                return false;
+            }
+            $target = strpos($ip, ':') !== false ? "[$ip]" : $ip;
+        } else {
+            $target = $host;
+        }
+
         $data = '';
         switch ($parts['scheme']) {
             case 'http':
-                $fsock = @fsockopen($parts['host'], isset($parts['port']) ? $parts['port'] : 80);
+                $fsock = @fsockopen($target, $port);
                 if (!$fsock) {
                     return false;
                 }
-                $path = $parts['path'];
+                $path = isset($parts['path']) ? $parts['path'] : '/';
                 if (isset($parts['query'])) {
                     $path .= '?' . $parts['query'];
                 }
                 fputs($fsock, "GET $path HTTP/1.0\r\n");
-                fputs($fsock, "Host: $parts[host]\r\n\r\n");
+                fputs($fsock, "Host: $host\r\n\r\n");
                 $line = fgets($fsock, 1024);
-                if (strlen($line) < 3) {
+                if ($line === false || strlen($line) < 3) {
                     return false;
                 }
-                preg_match('#HTTP/1.\d (\d{3})#', $line, $temp);
-                if ($temp[1] != '200') {
+                if (!preg_match('#HTTP/1.\d (\d{3})#', $line, $temp) || $temp[1] != '200') {
                     return false;
                 }
 
@@ -1162,7 +1211,8 @@ class X509
                 break;
             //case 'ftp':
             //case 'ldap':
-            //default:
+            default:
+                return false;
         }
 
         return $data;
@@ -1242,6 +1292,7 @@ class X509
      *
      * @param bool $caonly optional
      * @return mixed
+     * @changed in phpseclib 4.0.0
      */
     public function validateSignature($caonly = true)
     {
@@ -1473,6 +1524,7 @@ class X509
     /**
      * Prevents URIs from being automatically retrieved
      *
+     * @removed in phpseclib 4.0.0
      */
     public static function disableURLFetch()
     {
@@ -1482,6 +1534,7 @@ class X509
     /**
      * Allows URIs to be automatically retrieved
      *
+     * @removed in phpseclib 4.0.0
      */
     public static function enableURLFetch()
     {
@@ -1495,6 +1548,7 @@ class X509
      *
      * @param string $ip
      * @return string
+     * @removed in phpseclib 4.0.0
      */
     public static function decodeIP($ip)
     {
@@ -1508,6 +1562,7 @@ class X509
      *
      * @param string $ip
      * @return array
+     * @removed in phpseclib 4.0.0
      */
     public static function decodeNameConstraintIP($ip)
     {
@@ -1524,6 +1579,7 @@ class X509
      *
      * @param string|array $ip
      * @return string
+     * @removed in phpseclib 4.0.0
      */
     public static function encodeIP($ip)
     {
@@ -1647,6 +1703,7 @@ class X509
      * @param mixed $propValue
      * @param string $type optional
      * @return bool
+     * @removed in phpseclib 4.0.0
      */
     public function setDNProp($propName, $propValue, $type = 'utf8String')
     {
@@ -1677,6 +1734,7 @@ class X509
      * Remove Distinguished Name properties
      *
      * @param string $propName
+     * @removed in phpseclib 4.0.0
      */
     public function removeDNProp($propName)
     {
@@ -1710,6 +1768,7 @@ class X509
      * @param array $dn optional
      * @param bool $withType optional
      * @return mixed
+     * @removed in phpseclib 4.0.0
      */
     public function getDNProp($propName, $dn = null, $withType = false)
     {
@@ -1774,6 +1833,7 @@ class X509
      * @param bool $merge optional
      * @param string $type optional
      * @return bool
+     * @changed in phpseclib 4.0.0
      */
     public function setDN($dn, $merge = false, $type = 'utf8String')
     {
@@ -1815,6 +1875,7 @@ class X509
      * @param mixed $format optional
      * @param array $dn optional
      * @return array|bool|string
+     * @changed in phpseclib 4.0.0
      */
     public function getDN($format = self::DN_ARRAY, $dn = null)
     {
@@ -1956,6 +2017,7 @@ class X509
      *
      * @param int $format optional
      * @return mixed
+     * @changed in phpseclib 4.0.0
      */
     public function getIssuerDN($format = self::DN_ARRAY)
     {
@@ -1977,6 +2039,7 @@ class X509
      *
      * @param int $format optional
      * @return mixed
+     * @changed in phpseclib 4.0.0
      */
     public function getSubjectDN($format = self::DN_ARRAY)
     {
@@ -2000,6 +2063,7 @@ class X509
      * @param string $propName
      * @param bool $withType optional
      * @return mixed
+     * @removed in phpseclib 4.0.0
      */
     public function getIssuerDNProp($propName, $withType = false)
     {
@@ -2021,6 +2085,7 @@ class X509
      * @param string $propName
      * @param bool $withType optional
      * @return mixed
+     * @removed in phpseclib 4.0.0
      */
     public function getSubjectDNProp($propName, $withType = false)
     {
@@ -2042,6 +2107,7 @@ class X509
      * Get the certificate chain for the current cert
      *
      * @return mixed
+     * @removed in phpseclib 4.0.0
      */
     public function getChain()
     {
@@ -2083,6 +2149,7 @@ class X509
      * Returns the current cert
      *
      * @return array|bool
+     * @removed in phpseclib 4.0.0
      */
     public function &getCurrentCert()
     {
@@ -2108,6 +2175,7 @@ class X509
      * Key needs to be a \phpseclib3\Crypt\RSA object
      *
      * @param PrivateKey $key
+     * @removed in phpseclib 4.0.0
      */
     public function setPrivateKey(PrivateKey $key)
     {
@@ -2120,6 +2188,7 @@ class X509
      * Used for SPKAC CSR's
      *
      * @param string $challenge
+     * @removed in phpseclib 4.0.0
      */
     public function setChallenge($challenge)
     {
@@ -2180,6 +2249,7 @@ class X509
      * @param string $csr
      * @param int $mode
      * @return mixed
+     * @removed in phpseclib 4.0.0
      */
     public function loadCSR($csr, $mode = self::FORMAT_AUTO_DETECT)
     {
@@ -2254,6 +2324,7 @@ class X509
      * @param array $csr
      * @param int $format optional
      * @return string
+     * @removed in phpseclib 4.0.0
      */
     public function saveCSR(array $csr, $format = self::FORMAT_PEM)
     {
@@ -2299,6 +2370,7 @@ class X509
      *
      * @param string $spkac
      * @return mixed
+     * @removed in phpseclib 4.0.0
      */
     public function loadSPKAC($spkac)
     {
@@ -2363,6 +2435,7 @@ class X509
      * @param array $spkac
      * @param int $format optional
      * @return string
+     * @removed in phpseclib 4.0.0
      */
     public function saveSPKAC(array $spkac, $format = self::FORMAT_PEM)
     {
@@ -2400,6 +2473,7 @@ class X509
      * @param string $crl
      * @param int $mode
      * @return mixed
+     * @removed in phpseclib 4.0.0
      */
     public function loadCRL($crl, $mode = self::FORMAT_AUTO_DETECT)
     {
@@ -2466,6 +2540,7 @@ class X509
      * @param array $crl
      * @param int $format optional
      * @return string
+     * @removed in phpseclib 4.0.0
      */
     public function saveCRL(array $crl, $format = self::FORMAT_PEM)
     {
@@ -2546,6 +2621,7 @@ class X509
      * a CSR or something with the DN and public key explicitly set.
      *
      * @return mixed
+     * @removed in phpseclib 4.0.0
      */
     public function sign(X509 $issuer, X509 $subject)
     {
@@ -2728,6 +2804,7 @@ class X509
      * Sign a CSR
      *
      * @return mixed
+     * @removed in phpseclib 4.0.0
      */
     public function signCSR()
     {
@@ -2783,6 +2860,7 @@ class X509
      * Sign a SPKAC
      *
      * @return mixed
+     * @removed in phpseclib 4.0.0
      */
     public function signSPKAC()
     {
@@ -2845,6 +2923,7 @@ class X509
      * $issuer's private key needs to be loaded.
      *
      * @return mixed
+     * @removed in phpseclib 4.0.0
      */
     public function signCRL(X509 $issuer, X509 $crl)
     {
@@ -3395,6 +3474,7 @@ class X509
      * @param array $cert optional
      * @param string $path optional
      * @return array
+     * @removed in phpseclib 4.0.0
      */
     public function getExtensions($cert = null, $path = null)
     {
@@ -3421,6 +3501,7 @@ class X509
      * @param string $id
      * @param int $disposition optional
      * @return bool
+     * @removed in phpseclib 4.0.0
      */
     public function removeAttribute($id, $disposition = self::ATTR_ALL)
     {
@@ -3471,6 +3552,7 @@ class X509
      * @param int $disposition optional
      * @param array $csr optional
      * @return mixed
+     * @removed in phpseclib 4.0.0
      */
     public function getAttribute($id, $disposition = self::ATTR_ALL, $csr = null)
     {
@@ -3512,6 +3594,7 @@ class X509
      *
      * @param array $csr optional
      * @return mixed
+     * @removed in phpseclib 4.0.0
      */
     public function getRequestedCertificateExtensions($csr = null)
     {
@@ -3532,6 +3615,7 @@ class X509
      *
      * @param array $csr optional
      * @return array
+     * @removed in phpseclib 4.0.0
      */
     public function getAttributes($csr = null)
     {
@@ -3558,6 +3642,7 @@ class X509
      * @param mixed $value
      * @param int $disposition optional
      * @return bool
+     * @removed in phpseclib 4.0.0
      */
     public function setAttribute($id, $value, $disposition = self::ATTR_ALL)
     {
@@ -3639,6 +3724,7 @@ class X509
      * @param mixed $key optional
      * @param int $method optional
      * @return string binary key identifier
+     * @removed in phpseclib 4.0.0
      */
     public function computeKeyIdentifier($key = null, $method = 1)
     {
@@ -3735,6 +3821,7 @@ class X509
      *
      * @param mixed ...$domains
      * @return void
+     * @removed in phpseclib 4.0.0
      */
     public function setDomain(...$domains)
     {
@@ -3747,6 +3834,7 @@ class X509
      * Set the IP Addresses's which the cert is to be valid for
      *
      * @param mixed[] ...$ipAddresses
+     * @removed in phpseclib 4.0.0
      */
     public function setIPAddress(...$ipAddresses)
     {
@@ -3843,6 +3931,7 @@ class X509
      *
      * @param string $serial
      * @return bool
+     * @removed in phpseclib 4.0.0
      */
     public function unrevoke($serial)
     {
@@ -3862,6 +3951,7 @@ class X509
      *
      * @param string $serial
      * @return mixed
+     * @removed in phpseclib 4.0.0
      */
     public function getRevoked($serial)
     {
@@ -3879,6 +3969,7 @@ class X509
      *
      * @param array $crl optional
      * @return array|bool
+     * @removed in phpseclib 4.0.0
      */
     public function listRevoked($crl = null)
     {
@@ -3907,6 +3998,7 @@ class X509
      * @param string $serial
      * @param string $id
      * @return bool
+     * @removed in phpseclib 4.0.0
      */
     public function removeRevokedCertificateExtension($serial, $id)
     {
@@ -3928,6 +4020,7 @@ class X509
      * @param string $id
      * @param array $crl optional
      * @return mixed
+     * @removed in phpseclib 4.0.0
      */
     public function getRevokedCertificateExtension($serial, $id, $crl = null)
     {
@@ -3975,6 +4068,7 @@ class X509
      * @param bool $critical optional
      * @param bool $replace optional
      * @return bool
+     * @removed in phpseclib 4.0.0
      */
     public function setRevokedCertificateExtension($serial, $id, $value, $critical = false, $replace = true)
     {
@@ -4025,9 +4119,20 @@ class X509
      * @param mixed $value
      * @param bool $critical
      * @param bool $replace
+     * @removed in phpseclib 4.0.0
      */
     public function setExtensionValue($id, $value, $critical = false, $replace = false)
     {
         $this->extensionValues[$id] = compact('critical', 'replace', 'value');
+    }
+
+    /**
+     * Returns the OID corresponding to a name
+     *
+     * @param ?callable $callback
+     */
+    public static function setURLFetchCallback($callback)
+    {
+        self::$urlFetchCallback = $callback;
     }
 }

--- a/vendor/phpseclib/phpseclib/phpseclib/Math/BigInteger.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Math/BigInteger.php
@@ -322,6 +322,7 @@ class BigInteger implements \JsonSerializable
      *
      * @param BigInteger $n
      * @return BigInteger
+     * @changed in phpseclib 4.0.0
      */
     public function modInverse(BigInteger $n)
     {

--- a/vendor/phpseclib/phpseclib/phpseclib/Math/BigInteger/Engines/GMP.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Math/BigInteger/Engines/GMP.php
@@ -120,8 +120,7 @@ class GMP extends Engine
     public function toBits($twos_compliment = false)
     {
         $hex = $this->toHex($twos_compliment);
-
-        $bits = gmp_strval(gmp_init($hex, 16), 2);
+        $bits = strlen($hex) ? gmp_strval(gmp_init($hex, 16), 2) : '';
 
         if ($this->precision > 0) {
             $bits = substr($bits, -$this->precision);

--- a/vendor/phpseclib/phpseclib/phpseclib/Net/SFTP.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Net/SFTP.php
@@ -1681,6 +1681,7 @@ class SFTP extends SSH2
      * @param bool $recursive
      * @throws \UnexpectedValueException on receipt of unexpected packets
      * @return mixed
+     * @changed in phpseclib 4.0.0
      */
     public function chmod($mode, $filename, $recursive = false)
     {
@@ -3466,6 +3467,7 @@ class SFTP extends SSH2
      * Returns all errors on the SFTP layer
      *
      * @return array
+     * @removed in phpseclib 4.0.0
      */
     public function getSFTPErrors()
     {
@@ -3476,6 +3478,7 @@ class SFTP extends SSH2
      * Returns the last error on the SFTP layer
      *
      * @return string
+     * @removed in phpseclib 4.0.0
      */
     public function getLastSFTPError()
     {
@@ -3785,5 +3788,51 @@ class SFTP extends SSH2
             ['bsize', 'frsize', 'blocks', 'bfree', 'bavail', 'files', 'ffree', 'favail', 'fsid', 'flag', 'namemax'],
             Strings::unpackSSH2('QQQQQQQQQQQ', $response)
         );
+    }
+
+    public function hardlink($oldpath, $newpath)
+    {
+        if (!$this->precheck()) {
+            return false;
+        }
+
+        if (!isset($this->extensions['hardlink@openssh.com']) || $this->extensions['hardlink@openssh.com'] !== '1') {
+            throw new \RuntimeException(
+                "Extension 'hardlink@openssh.com' is not supported by the server. " .
+                "Call getSupportedVersions() to see a list of supported extension"
+            );
+        }
+
+        $oldpath = $this->realpath($oldpath);
+        $newpath = $this->realpath($newpath);
+        if ($oldpath === false || $newpath === false) {
+            return false;
+        }
+
+        $packet = Strings::packSSH2('sss', 'hardlink@openssh.com', $oldpath, $newpath);
+        $this->send_sftp_packet(NET_SFTP_EXTENDED, $packet);
+
+        $response = $this->get_sftp_packet();
+        if ($this->packet_type !== NET_SFTP_STATUS) {
+            throw new \UnexpectedValueException('Expected NET_SFTP_STATUS. '
+                . 'Got packet type: ' . $this->packet_type);
+        }
+
+        // if $status isn't SSH_FX_OK it's probably SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED
+        list($status) = Strings::unpackSSH2('N', $response);
+        if ($status !== NET_SFTP_STATUS_OK) {
+            $this->logError($response, $status);
+            return false;
+        }
+
+        // this operation will change the ctime and link-count attributes
+        // which could be cached depending on sftp version
+        $this->remove_from_stat_cache($oldpath);
+
+        // hardlink creation should fail if $newpath exists;
+        // removing it from the cache anyway, just to be sure
+        $this->remove_from_stat_cache($newpath);
+
+        return true;
     }
 }

--- a/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php
@@ -4913,6 +4913,7 @@ class SSH2
      * If you are looking for messages from the SFTP layer, please see SFTP::getSFTPErrors()
      *
      * @return string[]
+     * @removed in phpseclib 4.0.0
      */
     public function getErrors()
     {
@@ -4925,6 +4926,7 @@ class SSH2
      * If you are looking for messages from the SFTP layer, please see SFTP::getLastSFTPError()
      *
      * @return string
+     * @removed in phpseclib 4.0.0
      */
     public function getLastError()
     {


### PR DESCRIPTION
## Summary
- Ran `composer update`: **phpseclib 3.0.52 → 3.0.55** (security/maintenance patch release). `connect-helpers` (dev-main) unchanged.
- Set the 0.1.3.4 changelog release date in `readme.txt` (Beta → 17-06-2026).
- Includes the merge of latest `develop` into this branch.

## Changes
- `composer.lock`, `vendor/composer/*`, `vendor/phpseclib/**` — regenerated by composer update.
- `readme.txt` — release date + shortened two-way sync changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)