### PR TITLE
chore(ci): use Sonnet for Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -104,4 +104,4 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--model opus --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model sonnet --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
## What
Switch the **Claude Code Review** GitHub Action model from Opus to Sonnet (`claude_args: --model sonnet`).

## Why
Faster, cheaper PR reviews; Sonnet is sufficient for the automated code-review pass.

## Change
One line in `.github/workflows/claude-code-review.yml`:
`--model opus` → `--model sonnet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)