### PR TITLE
chore: release 0.1.3.5 — soft flush rewrite rules on cache clear

### DIFF
--- a/instawp-connect.php
+++ b/instawp-connect.php
@@ -8,7 +8,7 @@
  * @wordpress-plugin
  * Plugin Name:       InstaWP Connect
  * Description:       1-click WordPress plugin for Staging, Migrations, Management, Sync and Companion plugin for InstaWP.
- * Version:           0.1.3.4
+ * Version:           0.1.3.5
  * Author:            InstaWP Team
  * Author URI:        https://instawp.com/
  * License:           GPL-3.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 global $wpdb;
 
-defined( 'INSTAWP_PLUGIN_VERSION' ) || define( 'INSTAWP_PLUGIN_VERSION', '0.1.3.4' );
+defined( 'INSTAWP_PLUGIN_VERSION' ) || define( 'INSTAWP_PLUGIN_VERSION', '0.1.3.5' );
 defined( 'INSTAWP_API_DOMAIN_PROD' ) || define( 'INSTAWP_API_DOMAIN_PROD', 'https://app.instawp.io' );
 
 defined( 'INSTAWP_PLUGIN_URL' ) || define( 'INSTAWP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: clone, migrate, staging, backup, restore
 Requires at least: 5.6
 Tested up to: 7.0
 Requires PHP: 7.0
-Stable tag: 0.1.3.4
+Stable tag: 0.1.3.5
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 
@@ -97,6 +97,9 @@ Need support or want to partner with us? Go to our [website](http://instawp.com/
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team helps validate, triage, and handle any security vulnerabilities. [Report a security vulnerability](https://patchstack.com/database/vdp/instawp-connect).
 
 == Changelog ==
+
+= 0.1.3.5 - 29 June 2026 =
+- Fixed: Soft flush rewrite rules on cache clear.
 
 = 0.1.3.4 - 17 June 2026 =
 - Added: Migration engine detection — end-to-end migrations now auto-route to the v3 or v4 (InstaMigrate) flow.


### PR DESCRIPTION
## Summary
- Bump plugin version `0.1.3.4` → `0.1.3.5`
- Add changelog entry for the soft rewrite flush fix

## Changes
- `instawp-connect.php` — `Version:` header and `INSTAWP_PLUGIN_VERSION` → `0.1.3.5`
- `readme.txt` — `Stable tag: 0.1.3.5` and new changelog section:
  - **Fixed:** Soft flush rewrite rules on cache clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)