### PR TITLE
fix: build the large files list on demand instead of an hourly full-filesystem walk

### DIFF
--- a/doc/large-files-list.md
+++ b/doc/large-files-list.md
@@ -1,0 +1,35 @@
+# Large files list
+
+The migrate / create-staging screen offers to exclude "large files" (anything over
+`instawp_max_file_size_allowed`, default 50 MB) from a migration. The candidates are cached in the
+`instawp_large_files_list` option.
+
+## How the list is built
+
+Building the list means a full recursive `stat()` walk of `ABSPATH`
+(`instaWP::prepare_large_files_list()`), so it is only run **on demand**:
+
+- `instaWP::maybe_prepare_large_files_list()` builds it when the `instawp_generate_large_files`
+  transient (1 hour) has expired. The migrate screen calls this while rendering, so the scan happens
+  only on sites where somebody actually opens the migration UI.
+- The **Refresh** button on the Exclude step forces a rebuild (`instawp_get_large_files` AJAX with
+  `generate=true`).
+- Changing `instawp_max_file_size_allowed` invalidates the cache
+  (`instaWP::clear_staging_sites_list()`); the list is rebuilt the next time the screen is opened.
+
+There is **no recurring cron for this scan**. Before 0.1.3.6 it ran hourly as an Action Scheduler
+recurring action, which meant every site walked its whole filesystem every hour — inside the PHP-FPM
+web pool via the wp-cron loopback — whether or not the site ever migrated. `register_actions()` now
+unschedules that legacy action once per site and records it in the `instawp_large_files_cron_removed`
+option.
+
+## Disabling the scan
+
+Hosts that never want the walk (e.g. sites on very large or network filesystems) can turn it off:
+
+```php
+add_filter( 'instawp_large_files_scan_enabled', '__return_false' );
+```
+
+The list is then always empty and the Exclude step simply shows no large-file suggestions;
+migrations are unaffected.

--- a/includes/class-instawp.php
+++ b/includes/class-instawp.php
@@ -103,13 +103,29 @@ class instaWP {
 	}
 
 	public function register_actions() {
-		if ( ! as_has_scheduled_action( 'instawp_prepare_large_files_list', array(), 'instawp-connect' ) ) {
-			as_schedule_recurring_action( time(), HOUR_IN_SECONDS, 'instawp_prepare_large_files_list', array(), 'instawp-connect' );
-		}
+		$this->unschedule_large_files_list();
 
 		if ( ! as_has_scheduled_action( 'instawp_clean_migrate_files', array(), 'instawp-connect' ) ) {
 			as_schedule_recurring_action( time(), DAY_IN_SECONDS, 'instawp_clean_migrate_files', array(), 'instawp-connect' );
 		}
+	}
+
+	/**
+	 * Cancel the legacy hourly large files scan.
+	 *
+	 * The list is built on demand now, but sites upgrading from an earlier version still carry the
+	 * recurring action, so it has to be unscheduled once.
+	 *
+	 * @return void
+	 */
+	private function unschedule_large_files_list() {
+		if ( 'yes' === Option::get_option( 'instawp_large_files_cron_removed' ) ) {
+			return;
+		}
+
+		as_unschedule_all_actions( 'instawp_prepare_large_files_list', array(), 'instawp-connect' );
+
+		Option::update_option( 'instawp_large_files_cron_removed', 'yes', true );
 	}
 
 	public function clean_migrate_files() {
@@ -123,7 +139,30 @@ class instaWP {
 		}
 	}
 
+	/**
+	 * Build the large files list, but only when it is missing or stale.
+	 *
+	 * Scanning ABSPATH is a full recursive stat() walk, so it runs only when a screen actually needs
+	 * the list and the cached result has expired.
+	 *
+	 * @return void
+	 */
+	public function maybe_prepare_large_files_list() {
+		if ( get_transient( 'instawp_generate_large_files' ) ) {
+			return;
+		}
+
+		$this->prepare_large_files_list();
+	}
+
 	public function prepare_large_files_list() {
+		if ( ! apply_filters( 'instawp_large_files_scan_enabled', true ) ) {
+			set_transient( 'instawp_generate_large_files', true, HOUR_IN_SECONDS );
+			Option::update_option( 'instawp_large_files_list', array() );
+
+			return;
+		}
+
 		$maxbytes = (int) Option::get_option( 'instawp_max_file_size_allowed', INSTAWP_DEFAULT_MAX_FILE_SIZE_ALLOWED );
 		$maxbytes = $maxbytes ? $maxbytes : INSTAWP_DEFAULT_MAX_FILE_SIZE_ALLOWED;
 		$maxbytes = ( $maxbytes * 1024 * 1024 );
@@ -158,7 +197,7 @@ class instaWP {
 
 	public function clear_staging_sites_list() {
 		delete_option( 'instawp_large_files_list' );
-		do_action( 'instawp_prepare_large_files_list' );
+		delete_transient( 'instawp_generate_large_files' );
 	}
 
 	private function set_locale() {

--- a/instawp-connect.php
+++ b/instawp-connect.php
@@ -59,7 +59,6 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/functions.php';
 
 function instawp_plugin_activate() {
 	InstaWP_Tools::instawp_reset_permalink();
-	do_action( 'instawp_prepare_large_files_list' );
 
 	// set default user for sync settings if user empty
 	$default_user = Option::get_option( 'instawp_default_user' );

--- a/migrate/templates/part-create-staging.php
+++ b/migrate/templates/part-create-staging.php
@@ -38,6 +38,7 @@ $customize_options     = array(
 $current_create_screen = isset( $_GET['screen'] ) ? intval( $_GET['screen'] ) : 1;
 $tables                = instawp_get_database_details();
 $log_tables_to_exclude = InstaWP_Tools::get_log_tables_to_exclude();
+instawp()->maybe_prepare_large_files_list();
 $list_data             = Option::get_option( 'instawp_large_files_list' );
 $migration_details     = Helper::get_args_option( 'instawp_migration_details', $instawp_settings );
 $tracking_url          = Helper::get_args_option( 'tracking_url', $migration_details );

--- a/uninstall.php
+++ b/uninstall.php
@@ -60,6 +60,7 @@ if ( ! empty( $connect_id ) && ! empty( $api_key ) ) {
 
 delete_option( 'instawp_api_options' );
 delete_option( 'instawp_large_files_list' );
+delete_option( 'instawp_large_files_cron_removed' );
 delete_option( 'instawp_backup_part_size' );
 delete_option( 'instawp_max_file_size_allowed' );
 delete_option( 'instawp_reset_type' );


### PR DESCRIPTION
## Root cause

`instawp_prepare_large_files_list` was scheduled as an **hourly recurring Action Scheduler action** on every site (`includes/class-instawp.php:106-107`). The handler is a **full recursive `stat()` walk of the whole of `ABSPATH`** — `RecursiveIteratorIterator(new RecursiveDirectoryIterator(ABSPATH))`, calling `getSize()` on every file.

Because Action Scheduler runs via the wp-cron loopback, that walk executes **inside the site's PHP-FPM web pool**, competing with real visitors for the 2–3 workers a site has. It is pure syscall/I/O time, so **`max_execution_time` cannot stop it** (that only counts CPU/script time) — a slow walk holds its worker for the full `request_terminate_timeout` (300s). That is a textbook producer of **D-state (uninterruptible sleep) FPM workers**, and on a 2-worker pool two of them take the whole site down with a 504 while the box sits idle.

## Impact

This ran hourly on **every site with instawp-connect + wp-cron enabled** — most of the ~27k PPU fleet — on a **migration-only feature that the vast majority of those sites never use**. `instawp_large_files_list` is read **only** by the migrate / create-staging UI (the "exclude large files" suggestions, `migrate/templates/part-create-staging.php` + the `instawp_get_large_files` / `instawp_get_directory` AJAX handlers). The migration engine itself never reads it.

## The fix — build it on demand

- **No recurring cron.** `register_actions()` no longer schedules the hourly action, and **unschedules the legacy one once per site** (`as_unschedule_all_actions`, recorded in the `instawp_large_files_cron_removed` option) — so the ~27k sites already carrying the recurring action actually stop walking, not just new installs.
- **Lazy build.** New `instaWP::maybe_prepare_large_files_list()` rebuilds only when the **existing** `instawp_generate_large_files` transient (1h) has expired. The migrate screen calls it while rendering, so the walk happens only on sites where somebody actually opens the migration UI, at most once an hour.
- **Activation no longer walks the filesystem** (`instawp_plugin_activate()` did a synchronous full scan on every site creation).
- **Changing `instawp_max_file_size_allowed`** now just invalidates the cache instead of re-walking inline.
- **Opt-out:** new `instawp_large_files_scan_enabled` filter (`__return_false`) disables the scan entirely — a fleet-wide kill switch via mu-plugin.

## Behaviour / compatibility

- The Exclude step shows the same list; the **Refresh** button still forces a rebuild (`generate=true`), unchanged.
- The `instawp_prepare_large_files_list` action hook is still registered, so any external `do_action()` caller keeps working.
- No change to Action Scheduler's own `action_scheduler_run_queue` recurrence (stock AS, deliberately untouched).
- Docs: `doc/large-files-list.md`.

## Review

Cross-model second opinion (z.ai GLM) run over the diff — its one "blocking" finding (missing `set_transient` in `prepare_large_files_list()`) is a **false positive**: it only saw the diff hunks, and the `set_transient()` is pre-existing code at `class-instawp.php:194`. No other findings.

**Next step (human): run `/code-review ultra` on this PR before merge.** QA verification (migrate screen still lists large files, exclusion still applies) is being handed to the QA agent.

Related: KB runbook `runbooks/fleet-504-two-worker-pools`.

— Engineer (agent-os)
