### PR TITLE
fix: checkbox checked state visibility on events screen

### DIFF
--- a/admin/css/instawp-change-event.css
+++ b/admin/css/instawp-change-event.css
@@ -576,11 +576,6 @@ span.select2-selection.select2-selection {
     line-height: unset !important;
 }
 
-#select-all-event:checked, .single-event-cb:checked {
-    border-color: #6b7280 !important;
-    background: #fff !important;
-}
-
 @keyframes blink {
     50% {
         opacity: 0;

--- a/instawp-connect.php
+++ b/instawp-connect.php
@@ -8,7 +8,7 @@
  * @wordpress-plugin
  * Plugin Name:       InstaWP Connect
  * Description:       1-click WordPress plugin for Staging, Migrations, Management, Sync and Companion plugin for InstaWP.
- * Version:           0.1.3.5
+ * Version:           0.1.3.6
  * Author:            InstaWP Team
  * Author URI:        https://instawp.com/
  * License:           GPL-3.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 global $wpdb;
 
-defined( 'INSTAWP_PLUGIN_VERSION' ) || define( 'INSTAWP_PLUGIN_VERSION', '0.1.3.5' );
+defined( 'INSTAWP_PLUGIN_VERSION' ) || define( 'INSTAWP_PLUGIN_VERSION', '0.1.3.6' );
 defined( 'INSTAWP_API_DOMAIN_PROD' ) || define( 'INSTAWP_API_DOMAIN_PROD', 'https://app.instawp.io' );
 
 defined( 'INSTAWP_PLUGIN_URL' ) || define( 'INSTAWP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: clone, migrate, staging, backup, restore
 Requires at least: 5.6
 Tested up to: 7.0
 Requires PHP: 7.0
-Stable tag: 0.1.3.5
+Stable tag: 0.1.3.6
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 
@@ -97,6 +97,9 @@ Need support or want to partner with us? Go to our [website](http://instawp.com/
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team helps validate, triage, and handle any security vulnerabilities. [Report a security vulnerability](https://patchstack.com/database/vdp/instawp-connect).
 
 == Changelog ==
+
+= 0.1.3.6 - 22 July 2026 =
+- Fixed: Checkbox checked state not visible on the events screen in admin dashboard.
 
 = 0.1.3.5 - 29 June 2026 =
 - Fixed: Soft flush rewrite rules on cache clear.


### PR DESCRIPTION
## Problem

On the admin dashboard events screen, checked checkboxes did not visually appear checked. A CSS rule forced a white background on the `:checked` state, which hid the native checkmark.

## Change

- Removed the `#select-all-event:checked, .single-event-cb:checked` override in `admin/css/instawp-change-event.css` so checkboxes fall back to the default WordPress checked styling.
- Bumped plugin version `0.1.3.5` → `0.1.3.6` (`instawp-connect.php` header + `INSTAWP_PLUGIN_VERSION`, `readme.txt` stable tag).
- Added changelog entry in `readme.txt`.

## Testing

Open the events screen in wp-admin, toggle the select-all checkbox and individual event checkboxes — the checked state should now be visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZZb6mjtRxNSorxR4CBMjE