### PR TITLE
docs: add changelog entry for on-demand large files list (#517)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -100,6 +100,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 = 0.1.3.6 - 22 July 2026 =
 - Fixed: Checkbox checked state not visible on the events screen in admin dashboard.
+- Fixed: Large files list is now built on demand instead of an hourly full-filesystem scan, removing a major source of site slowdowns and timeouts.
 
 = 0.1.3.5 - 29 June 2026 =
 - Fixed: Soft flush rewrite rules on cache clear.

--- a/readme.txt
+++ b/readme.txt
@@ -100,7 +100,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 = 0.1.3.6 - 22 July 2026 =
 - Fixed: Checkbox checked state not visible on the events screen in admin dashboard.
-- Fixed: Large files list is now built on demand instead of an hourly full-filesystem scan, removing a major source of site slowdowns and timeouts.
+- Fixed: Large files list is now built on demand instead of an hourly full-filesystem scan.
 
 = 0.1.3.5 - 29 June 2026 =
 - Fixed: Soft flush rewrite rules on cache clear.


### PR DESCRIPTION
Adds the missing changelog line for PR #517, which was merged without a `readme.txt` entry.

```
= 0.1.3.6 - 22 July 2026 =
- Fixed: Large files list is now built on demand instead of an hourly full-filesystem scan, removing a major source of site slowdowns and timeouts.
```

Documentation only — no code changes. The version bump to `0.1.3.6` already landed via PR #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZZb6mjtRxNSorxR4CBMjE