### PR TITLE
fix: Config Manager treats conditionally-defined wp-config constants as global (vendor bump to connect-helpers ded3bdc)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 = 0.1.3.7 - 03 August 2026 =
 - Security: Hardened the handling and cleanup of temporary migration files.
 - Fixed: Config Manager no longer lists or rewrites platform-managed object cache constants (WP_REDIS_*), which could break object cache authentication on save.
+- Fixed: Config Manager no longer shows a constant defined inside a conditional block (such as a WP-CLI only setting) as if it applied to the whole site, and no longer rewrites it on save.
 
 = 0.1.3.6 - 22 July 2026 =
 - Fixed: Checkbox checked state not visible on the events screen in admin dashboard.

--- a/readme.txt
+++ b/readme.txt
@@ -100,6 +100,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 = 0.1.3.7 - 03 August 2026 =
 - Security: Hardened the handling and cleanup of temporary migration files.
+- Fixed: Config Manager no longer lists or rewrites platform-managed object cache constants (WP_REDIS_*), which could break object cache authentication on save.
 
 = 0.1.3.6 - 22 July 2026 =
 - Fixed: Checkbox checked state not visible on the events screen in admin dashboard.

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -7,19 +7,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/InstaWP/connect-helpers.git",
-                "reference": "379737f1626c3b776f8e087f28731b8969dc506a"
+                "reference": "ded3bdc61188b9174425771efc397c9c5c1ed364"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/InstaWP/connect-helpers/zipball/379737f1626c3b776f8e087f28731b8969dc506a",
-                "reference": "379737f1626c3b776f8e087f28731b8969dc506a",
+                "url": "https://api.github.com/repos/InstaWP/connect-helpers/zipball/ded3bdc61188b9174425771efc397c9c5c1ed364",
+                "reference": "ded3bdc61188b9174425771efc397c9c5c1ed364",
                 "shasum": ""
             },
             "require": {
                 "php": ">= 5.6",
                 "wp-cli/wp-config-transformer": "^1.3"
             },
-            "time": "2026-07-31T10:30:14+00:00",
+            "time": "2026-08-04T08:08:37+00:00",
             "default-branch": true,
             "type": "library",
             "installation-source": "dist",

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -7,19 +7,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/InstaWP/connect-helpers.git",
-                "reference": "e40678f5a7fd3e678e2706a0e72af76b97a3fd5f"
+                "reference": "379737f1626c3b776f8e087f28731b8969dc506a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/InstaWP/connect-helpers/zipball/e40678f5a7fd3e678e2706a0e72af76b97a3fd5f",
-                "reference": "e40678f5a7fd3e678e2706a0e72af76b97a3fd5f",
+                "url": "https://api.github.com/repos/InstaWP/connect-helpers/zipball/379737f1626c3b776f8e087f28731b8969dc506a",
+                "reference": "379737f1626c3b776f8e087f28731b8969dc506a",
                 "shasum": ""
             },
             "require": {
                 "php": ">= 5.6",
                 "wp-cli/wp-config-transformer": "^1.3"
             },
-            "time": "2026-06-09T10:48:48+00:00",
+            "time": "2026-07-31T10:30:14+00:00",
             "default-branch": true,
             "type": "library",
             "installation-source": "dist",

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -22,7 +22,7 @@
         'instawp/connect-helpers' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'e40678f5a7fd3e678e2706a0e72af76b97a3fd5f',
+            'reference' => '379737f1626c3b776f8e087f28731b8969dc506a',
             'type' => 'library',
             'install_path' => __DIR__ . '/../instawp/connect-helpers',
             'aliases' => array(

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -22,7 +22,7 @@
         'instawp/connect-helpers' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '379737f1626c3b776f8e087f28731b8969dc506a',
+            'reference' => 'ded3bdc61188b9174425771efc397c9c5c1ed364',
             'type' => 'library',
             'install_path' => __DIR__ . '/../instawp/connect-helpers',
             'aliases' => array(

--- a/vendor/instawp/connect-helpers/changelog.md
+++ b/vendor/instawp/connect-helpers/changelog.md
@@ -1,3 +1,9 @@
+v1.1.3
+======
+- Fixed: Config Manager no longer reports a constant whose `define()` sits inside a conditional block (e.g. the InstaCache `if ( WP_CLI )` guard) as global wp-config, and no longer rewrites or removes one.
+- Fixed: `WP_REDIS_*` object-cache config is excluded from Config Manager reads and writes, so saving a setting can no longer corrupt the Valkey ACL password.
+- Added: `set()`/`delete()` return a `skipped` list naming the constants that were protected, so a caller can tell a save apart from a silent no-op.
+
 v1.1.2
 ======
 - Added: Migration engine detection (v3/v4) via `getMigrationEngine()`.

--- a/vendor/instawp/connect-helpers/composer.json
+++ b/vendor/instawp/connect-helpers/composer.json
@@ -2,7 +2,7 @@
     "name": "instawp/connect-helpers",
     "description": "CLI Package for InstaWP Remote Features",
     "type": "library",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "license": "MIT",
     "authors": [
         {

--- a/vendor/instawp/connect-helpers/src/WPConfig.php
+++ b/vendor/instawp/connect-helpers/src/WPConfig.php
@@ -28,6 +28,27 @@ class WPConfig extends \WPConfigTransformer {
         'DOMAIN_CURRENT_SITE',
     ];
 
+    // InstaCache (Valkey/Redis) object-cache config is platform-managed and must never be
+    // round-tripped through the Config Manager: array-valued constants (WP_REDIS_PASSWORD =
+    // [acl_user, acl_pass]; WP_REDIS_SERVERS/CLUSTER/SENTINEL/SHARDS/*_GROUPS) collapse to a
+    // mangled string on save, breaking object-cache auth. A prefix match blacklists the whole
+    // family (present and future) rather than an enumerated, quickly-stale list.
+    protected $blacklisted_prefixes = [
+        'WP_REDIS_',
+    ];
+
+    protected function is_blacklisted( $constant ) {
+        if ( in_array( $constant, $this->blacklisted, true ) ) {
+            return true;
+        }
+        foreach ( $this->blacklisted_prefixes as $prefix ) {
+            if ( 0 === strpos( $constant, $prefix ) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public function __construct( array $constants = [], $is_cli = false, $read_only = false ) {
         $file = ABSPATH . 'wp-config.php';
         if ( ! file_exists( $file ) ) {
@@ -61,7 +82,7 @@ class WPConfig extends \WPConfigTransformer {
         ];
 
         foreach ( $this->wp_configs['constant'] as $constant => $data ) {
-            if ( ! $this->is_cli && ( preg_match( '/[a-z]/', $constant ) || in_array( $constant, $this->blacklisted, true ) ) ) {
+            if ( ! $this->is_cli && ( preg_match( '/[a-z]/', $constant ) || $this->is_blacklisted( $constant ) ) ) {
                 continue;
             }
 
@@ -104,7 +125,7 @@ class WPConfig extends \WPConfigTransformer {
                 continue;
             }
 
-            if ( ! $this->is_cli && ( preg_match( '/[a-z]/', $key ) || in_array( $key, $this->blacklisted, true ) ) ) {
+            if ( ! $this->is_cli && ( preg_match( '/[a-z]/', $key ) || $this->is_blacklisted( $key ) ) ) {
                 continue;
             }
 

--- a/vendor/instawp/connect-helpers/src/WPConfig.php
+++ b/vendor/instawp/connect-helpers/src/WPConfig.php
@@ -49,6 +49,422 @@ class WPConfig extends \WPConfigTransformer {
         return false;
     }
 
+    /**
+     * Control structures whose body we treat as a conditional scope.
+     *
+     * @return array
+     */
+    protected function scope_keywords() {
+        $keywords = [ T_IF, T_ELSEIF, T_ELSE, T_WHILE, T_FOR, T_FOREACH, T_SWITCH, T_DO, T_TRY, T_CATCH, T_FUNCTION ];
+
+        foreach ( [ 'T_FINALLY', 'T_FN', 'T_MATCH' ] as $maybe ) {
+            if ( defined( $maybe ) ) {
+                $keywords[] = constant( $maybe );
+            }
+        }
+
+        return $keywords;
+    }
+
+    /**
+     * Control structures that support PHP's alternative (colon) syntax.
+     *
+     * Deliberately excludes T_FUNCTION so a return type (`function f(): void`) is not
+     * mistaken for the start of a block.
+     *
+     * @return array
+     */
+    protected function alternative_syntax_keywords() {
+        return [ T_IF, T_ELSEIF, T_ELSE, T_WHILE, T_FOR, T_FOREACH, T_SWITCH ];
+    }
+
+    /**
+     * Names of constants whose define() does NOT sit at the top level of wp-config.php.
+     *
+     * WPConfigTransformer parses wp-config.php with a flat regex that has no awareness of
+     * enclosing scope, so a define() nested in a block — for example the InstaCache
+     * drop-in's
+     *
+     *     if ( defined( 'WP_CLI' ) && WP_CLI ) {
+     *         define( 'WP_REDIS_DISABLED', true );
+     *     }
+     *
+     * — is reported exactly like a top-level one. Surfacing such a constant to the Config
+     * Manager is wrong twice over: it advertises a value that does not apply to ordinary
+     * requests, and saving it back rewrites code inside a branch the caller never saw.
+     *
+     * A define() whose every enclosing condition names the constant itself — the ordinary
+     * `if ( ! defined( 'FOO' ) ) { define( 'FOO', ... ); }` idempotency guard — is
+     * unconditional in effect, so it stays manageable.
+     *
+     * Deliberate limitations, all of which fail towards today's behaviour rather than
+     * towards hiding a constant that is genuinely global:
+     *  - Without the tokenizer extension nothing is filtered at all.
+     *  - The result is keyed by NAME, so a constant defined both at the top level and
+     *    inside a block is left alone entirely. That is intentional: the transformer
+     *    rewrites by matching source text and we cannot tell which occurrence it would
+     *    edit, so refusing is the only safe answer.
+     *  - A brace-less body that immediately opens another statement
+     *    (`if ( $a )` newline `if ( ! defined( 'FOO' ) ) { ... }`) is judged on the inner
+     *    condition only; tracking the outer one needs statement-level parsing.
+     *
+     * @param string $src wp-config.php source.
+     *
+     * @return array Constant name => true.
+     */
+    protected function scoped_constants( $src ) {
+        if ( ! function_exists( 'token_get_all' ) ) {
+            return [];
+        }
+
+        $tokens = @token_get_all( $src );
+
+        if ( empty( $tokens ) ) {
+            return [];
+        }
+
+        $scope_keywords = $this->scope_keywords();
+        $alt_keywords   = $this->alternative_syntax_keywords();
+        $end_keywords   = [ T_ENDIF, T_ENDWHILE, T_ENDFOR, T_ENDFOREACH, T_ENDSWITCH ];
+
+        $trivia = [ T_WHITESPACE, T_COMMENT, T_DOC_COMMENT ];
+
+        $scoped  = [];
+        $stack   = [];   // One entry per open block: the header text that introduced it.
+        $header  = null; // Header text of the control structure currently being read.
+        $keyword = null; // Which keyword started that header.
+        $paren   = 0;    // Parenthesis depth, so a ternary ':' is not read as a block opener.
+        $expects_colon = false; // We are exactly at the ':' position of alternative syntax.
+        $condition_closed = false; // The current header's own condition has been closed.
+        $total   = count( $tokens );
+
+        for ( $index = 0; $index < $total; $index++ ) {
+            $token = $tokens[ $index ];
+
+            if ( is_array( $token ) ) {
+                $id   = $token[0];
+                $text = $token[1];
+
+                if ( in_array( $id, $trivia, true ) ) {
+                    if ( null !== $header ) {
+                        $header .= $text;
+                    }
+                    continue;
+                }
+
+                /* A close tag ends the statement exactly like a semicolon, so a brace-less
+                   body such as `if ( $a ) define( 'X', 1 ) ?>` must not leave the header
+                   open over the constants that follow it. */
+                if ( T_CLOSE_TAG === $id ) {
+                    $header  = null;
+                    $keyword = null;
+                    $expects_colon    = false;
+                    $condition_closed = false;
+                    continue;
+                }
+
+                if ( in_array( $id, $end_keywords, true ) ) {
+                    array_pop( $stack );
+                    $expects_colon = false;
+                    continue;
+                }
+
+                // A '{' that opens string interpolation ("{$a}", "${a}") is closed by a plain
+                // '}', so it has to be balanced here or every later define() looks nested.
+                if ( T_CURLY_OPEN === $id || T_DOLLAR_OPEN_CURLY_BRACES === $id ) {
+                    $stack[]       = '';
+                    $expects_colon = false;
+                    continue;
+                }
+
+                // A control keyword only opens a scope at the top of a statement. Inside
+                // parentheses it belongs to something else — a closure in a condition — and
+                // must not replace the header being read. PHP 7 also allows reserved words as
+                // member names, so `function for( $k ): string` still lexes T_FOR: taking that
+                // as a `for` header would read its return-type ':' as alternative syntax and
+                // push a scope nothing pops.
+                if ( in_array( $id, $scope_keywords, true ) && 0 === $paren && ! $this->is_member_name( $tokens, $index ) ) {
+                    $header  = $text;
+                    $keyword = $id;
+                    // `else` takes no condition, so its alternative-syntax ':' comes next.
+                    $expects_colon    = ( T_ELSE === $id );
+                    $condition_closed = ( T_ELSE === $id );
+                    continue;
+                }
+
+                if ( $this->is_define_token( $token ) && $this->is_define_call( $tokens, $index ) ) {
+                    // Inside a block, or a brace-less body such as `if ( ... ) define( ... );`.
+                    if ( ! empty( $stack ) || null !== $header ) {
+                        $enclosing = $stack;
+                        if ( null !== $header ) {
+                            $enclosing[] = $header;
+                        }
+
+                        $name = $this->define_name( $tokens, $index );
+
+                        if ( '' !== $name && ! $this->guards_itself( $enclosing, $name ) ) {
+                            $scoped[ $name ] = true;
+                        }
+                    }
+                    $expects_colon = false;
+                    continue;
+                }
+
+                if ( null !== $header ) {
+                    $header .= $text;
+                }
+
+                $expects_colon = false;
+                continue;
+            }
+
+            if ( '(' === $token ) {
+                $paren++;
+                $expects_colon = false;
+            } elseif ( ')' === $token ) {
+                $paren--;
+                // Only the ':' immediately after a control structure's OWN closing ')' opens an
+                // alternative-syntax block — hence $condition_closed, which stops a later call
+                // in a brace-less body from re-arming it. Without this, the ':' of a ternary
+                // (`if ( $a ) $b = $c ? d( $e ) : f();`) pushes a scope that nothing pops, and
+                // every constant below it in the file silently disappears.
+                if ( 0 === $paren && null !== $header && ! $condition_closed ) {
+                    $expects_colon    = true;
+                    $condition_closed = true;
+                }
+            }
+
+            if ( '{' === $token ) {
+                // A '{' inside parentheses is a closure or match body sitting in the middle of
+                // a condition — `if ( array_filter( $a, function ( $v ) { … } ) ) :`. It opens a
+                // scope, but the header it interrupts is still being read, so keep it: nulling
+                // it would stop the following ':' from pushing and leave the matching `endif`
+                // to pop the enclosing block instead.
+                if ( $paren > 0 ) {
+                    $stack[] = '';
+                    $expects_colon = false;
+                    continue;
+                }
+
+                $stack[] = ( null === $header ) ? '' : $header;
+                $header  = null;
+                $keyword = null;
+                $expects_colon    = false;
+                $condition_closed = false;
+                continue;
+            }
+
+            if ( '}' === $token ) {
+                array_pop( $stack );
+                $expects_colon = false;
+                continue;
+            }
+
+            if ( ':' === $token && $expects_colon && null !== $header && 0 === $paren && in_array( $keyword, $alt_keywords, true ) ) {
+                // `elseif:` / `else:` continue the same if-chain that a single `endif` closes,
+                // so they replace the open scope rather than nesting inside it.
+                if ( T_ELSEIF === $keyword || T_ELSE === $keyword ) {
+                    array_pop( $stack );
+                }
+
+                $stack[] = $header;
+                $header  = null;
+                $keyword = null;
+                $expects_colon    = false;
+                $condition_closed = false;
+                continue;
+            }
+
+            if ( ';' === $token && 0 === $paren ) {
+                // The statement ended without opening a block (a brace-less body, or `do ... while;`).
+                $header  = null;
+                $keyword = null;
+                $expects_colon    = false;
+                $condition_closed = false;
+                continue;
+            }
+
+            if ( null !== $header ) {
+                $header .= $token;
+            }
+
+            if ( ')' !== $token ) {
+                $expects_colon = false;
+            }
+        }
+
+        return $scoped;
+    }
+
+    /**
+     * Whether a token names the `define` function, in either the plain (`define`) or
+     * fully qualified (`\define`) form. PHP 8 lexes the latter as a single token.
+     *
+     * @param array|string $token
+     *
+     * @return bool
+     */
+    protected function is_define_token( $token ) {
+        if ( ! is_array( $token ) ) {
+            return false;
+        }
+
+        $ids = [ T_STRING ];
+
+        if ( defined( 'T_NAME_FULLY_QUALIFIED' ) ) {
+            $ids[] = constant( 'T_NAME_FULLY_QUALIFIED' );
+        }
+
+        if ( ! in_array( $token[0], $ids, true ) ) {
+            return false;
+        }
+
+        return 0 === strcasecmp( ltrim( $token[1], '\\' ), 'define' );
+    }
+
+    /**
+     * Index of the next token after $index that is not whitespace or a comment.
+     *
+     * @param array $tokens
+     * @param int   $index
+     * @param int   $step   1 to scan forwards, -1 to scan backwards.
+     *
+     * @return int|null
+     */
+    protected function next_significant( $tokens, $index, $step = 1 ) {
+        $trivia = [ T_WHITESPACE, T_COMMENT, T_DOC_COMMENT ];
+        $total  = count( $tokens );
+
+        for ( $cursor = $index + $step; $cursor >= 0 && $cursor < $total; $cursor += $step ) {
+            $token = $tokens[ $cursor ];
+
+            if ( is_array( $token ) && in_array( $token[0], $trivia, true ) ) {
+                continue;
+            }
+
+            return $cursor;
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether the token at $index is being used as a member/function NAME rather than as
+     * the keyword it lexes to. PHP 7 allows reserved words after `function`, `->`, `?->`
+     * and `::`, so `function for( $k )` and `$obj->if()` both reach us as control keywords.
+     *
+     * @param array $tokens
+     * @param int   $index
+     *
+     * @return bool
+     */
+    protected function is_member_name( $tokens, $index ) {
+        $before = $this->next_significant( $tokens, $index, -1 );
+
+        if ( null === $before || ! is_array( $tokens[ $before ] ) ) {
+            return false;
+        }
+
+        $names_follow = [ T_FUNCTION, T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_CONST ];
+
+        if ( defined( 'T_NULLSAFE_OBJECT_OPERATOR' ) ) {
+            $names_follow[] = constant( 'T_NULLSAFE_OBJECT_OPERATOR' );
+        }
+
+        return in_array( $tokens[ $before ][0], $names_follow, true );
+    }
+
+    /**
+     * Whether the `define` token at $index is a real function call and not a method
+     * name (`$obj->define(...)`, `Foo::define(...)`) or a declaration.
+     *
+     * @param array $tokens
+     * @param int   $index
+     *
+     * @return bool
+     */
+    protected function is_define_call( $tokens, $index ) {
+        $rejected = [ T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_FUNCTION, T_NS_SEPARATOR ];
+
+        if ( defined( 'T_NULLSAFE_OBJECT_OPERATOR' ) ) {
+            $rejected[] = constant( 'T_NULLSAFE_OBJECT_OPERATOR' );
+        }
+
+        $before = $this->next_significant( $tokens, $index, -1 );
+
+        if ( null !== $before && is_array( $tokens[ $before ] ) && in_array( $tokens[ $before ][0], $rejected, true ) ) {
+            return false;
+        }
+
+        $after = $this->next_significant( $tokens, $index );
+
+        return null !== $after && '(' === $tokens[ $after ];
+    }
+
+    /**
+     * The constant name of the define() call whose `define` token sits at $index.
+     *
+     * @param array $tokens
+     * @param int   $index
+     *
+     * @return string Empty when the name is not a plain string literal.
+     */
+    protected function define_name( $tokens, $index ) {
+        $open = $this->next_significant( $tokens, $index );
+
+        if ( null === $open || '(' !== $tokens[ $open ] ) {
+            return '';
+        }
+
+        $literal = $this->next_significant( $tokens, $open );
+
+        if ( null === $literal || ! is_array( $tokens[ $literal ] ) || T_CONSTANT_ENCAPSED_STRING !== $tokens[ $literal ][0] ) {
+            return '';
+        }
+
+        // The literal must BE the whole first argument: `define( 'PRE' . $suffix, 1 )` would
+        // otherwise register 'PRE' and hide a genuinely top-level define( 'PRE', ... ).
+        $separator = $this->next_significant( $tokens, $literal );
+
+        if ( null === $separator || ',' !== $tokens[ $separator ] ) {
+            return '';
+        }
+
+        return trim( $tokens[ $literal ][1], "'\"" );
+    }
+
+    /**
+     * Whether every enclosing condition is a `defined( 'FOO' )` test on the constant
+     * itself, i.e. the define() is only wrapped in its own idempotency guard and therefore
+     * applies unconditionally.
+     *
+     * The test is deliberately narrow: merely mentioning the name is not enough, or
+     * `if ( getenv( 'WP_DEBUG' ) === 'yes' ) { define( 'WP_DEBUG', true ); }` — a genuinely
+     * conditional define — would be waved through as global config. It is not exhaustive
+     * either: a self-guard ANDed with another test (`if ( ! defined( 'FS_METHOD' ) && ! WP_CLI )`)
+     * still counts as a guard, which under-detects in the same direction as before this change.
+     *
+     * @param array  $headers
+     * @param string $name
+     *
+     * @return bool
+     */
+    protected function guards_itself( $headers, $name ) {
+        if ( empty( $headers ) ) {
+            return true;
+        }
+
+        $pattern = '/\bdefined\s*\(\s*[\'"]' . preg_quote( $name, '/' ) . '[\'"]\s*\)/';
+
+        foreach ( $headers as $header ) {
+            if ( ! preg_match( $pattern, $header ) ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     public function __construct( array $constants = [], $is_cli = false, $read_only = false ) {
         $file = ABSPATH . 'wp-config.php';
         if ( ! file_exists( $file ) ) {
@@ -81,8 +497,10 @@ class WPConfig extends \WPConfigTransformer {
             'wp-config' => [],
         ];
 
+        $scoped = $this->is_cli ? [] : $this->scoped_constants( $this->wp_config_src );
+
         foreach ( $this->wp_configs['constant'] as $constant => $data ) {
-            if ( ! $this->is_cli && ( preg_match( '/[a-z]/', $constant ) || $this->is_blacklisted( $constant ) ) ) {
+            if ( ! $this->is_cli && ( preg_match( '/[a-z]/', $constant ) || $this->is_blacklisted( $constant ) || isset( $scoped[ $constant ] ) ) ) {
                 continue;
             }
 
@@ -120,12 +538,23 @@ class WPConfig extends \WPConfigTransformer {
             $args['placement'] = 'after';
         }
 
+        $scoped  = $this->is_cli ? [] : $this->scoped_constants( $content );
+        $skipped = [];
+
         foreach ( $this->config_data as $key => $value ) {
             if ( empty( $key ) ) {
                 continue;
             }
 
-            if ( ! $this->is_cli && ( preg_match( '/[a-z]/', $key ) || $this->is_blacklisted( $key ) ) ) {
+            if ( ! $this->is_cli && preg_match( '/[a-z]/', $key ) ) {
+                // Not a constant name we ever manage — a malformed key, not a protection.
+                continue;
+            }
+
+            if ( ! $this->is_cli && ( $this->is_blacklisted( $key ) || isset( $scoped[ $key ] ) ) ) {
+                // Report what was deliberately not written. The caller posts the whole constant
+                // map back, so without this a protected constant looks saved and silently reverts.
+                $skipped[] = $key;
                 continue;
             }
 
@@ -163,7 +592,13 @@ class WPConfig extends \WPConfigTransformer {
             }
         }
 
-        return [ 'success' => true ];
+        $response = [ 'success' => true ];
+
+        if ( ! empty( $skipped ) ) {
+            $response['skipped'] = $skipped;
+        }
+
+        return $response;
     }
 
     public function delete() {
@@ -173,7 +608,24 @@ class WPConfig extends \WPConfigTransformer {
             throw new \Exception( 'No constants provided!' );
         }
 
+        $scoped = [];
+
+        if ( ! $this->is_cli ) {
+            $content = file_get_contents( $this->wp_config_path );
+            $scoped  = $this->scoped_constants( $content );
+        }
+
+        $skipped = [];
+
         foreach ( $constants as $constant ) {
+            // Same protection get()/set() apply: the Config Manager never removes a
+            // blacklisted (platform-managed) constant, nor one that only exists inside a
+            // conditional block it was never able to show the caller.
+            if ( ! $this->is_cli && ( $this->is_blacklisted( $constant ) || isset( $scoped[ $constant ] ) ) ) {
+                $skipped[] = $constant;
+                continue;
+            }
+
             try {
                 $this->remove( 'constant', $constant );
             } catch ( \Exception $e ) {
@@ -181,6 +633,12 @@ class WPConfig extends \WPConfigTransformer {
             }
         }
 
-        return [ 'success' => true ];
+        $response = [ 'success' => true ];
+
+        if ( ! empty( $skipped ) ) {
+            $response['skipped'] = $skipped;
+        }
+
+        return $response;
     }
 }


### PR DESCRIPTION
## Reported

In the app, **Manage → Config Manager** shows `WP_REDIS_DISABLED` as an enabled constant, so it reads as though the Valkey/Redis object cache is switched off on the site.

## Root cause

It isn't off. `v-instawp-cache-enable` (instacp) writes that define **inside a CLI guard**:

```php
if (defined('WP_CLI') && WP_CLI) {
    define('WP_REDIS_DISABLED', true);
}
```

so it only applies to WP-CLI, never to web requests. But `WPConfig::get()` reads wp-config.php through `WPConfigTransformer::parse_wp_config()`, which is a **flat regex over the file text with no awareness of enclosing scope** — every `define()` at a line start matches, including one nested in an `if` block, a `switch` case or a function body. So a CLI-only constant is reported to the app as global site config, and `ConfigManager.vue` renders it as an ON toggle.

The app posts the **whole** constant map back on save, so the same flaw lets `update()` rewrite a define inside a branch the user was never shown — and is what collapses the array-valued `WP_REDIS_PASSWORD` (`[acl_user, acl_pass]`) into a mangled string and breaks Valkey ACL auth.

## Fix — vendor bump to connect-helpers `ded3bdc` (main)

The plugin's vendored copy was pinned at `e40678f` (Jun 2026) and had **neither** of the upstream fixes. This bumps it to `ded3bdc`, the current `main`, which carries both:

- **connect-helpers#21** — blacklist the `WP_REDIS_` prefix in `get()`/`set()`/`delete()` when `!is_cli`, so platform-managed object-cache config is neither displayed nor rewritten. Merged to `main` 2026-07-31 but never composer-updated into this plugin, so **no site had it**.
- **connect-helpers#22** — the general fix for this bug: a `token_get_all` scope scan, so a constant whose `define()` is not effectively top-level is not read, written or removed on the Config Manager path. A define wrapped only in its own `if ( ! defined( 'FOO' ) )` guard stays manageable, so hosts that write guarded constants don't lose Config Manager. Merged as `ded3bdc`.

After this bump the vendored package is **byte-identical to connect-helpers `main`** (verified with a full `diff -rq` of the package, including the absent trailing newline the reviewer noted — kept so the copy matches upstream exactly).

## Verification

- Vendored copy exercised in place: 20-case scanner suite, read/write round-trips, and `vendor/autoload.php` resolving the class — all green.
- The InstaCache case: before, the web path saw `WP_REDIS_SCHEME/PATH/PASSWORD/PREFIX/GRACEFUL/DISABLED` (with the password already collapsed to a string); after, it sees none of them. `is_cli` (migration / WP-CLI) still sees every constant, unchanged.
- Upstream: three code-review rounds, each executing the scanner. They found and fixed three scope leaks that would each have silently hidden *every* constant below them in wp-config.php. Final head verified with a stack-balance sweep over **2,316 real PHP files** (instawp-connect, cloud-app, client-app) with zero imbalance, plus a differential using PHP's own parser over 13,060 genuine top-level insertion points across 1,068 files with zero hidden.

## Notes for the reviewer bots' findings

1. **Hash mismatch** — correct, and now fixed: this body originally described the first push (`379737f`, the #21 blacklist alone). The branch was re-pointed at `ded3bdc` once #22 merged, so one plugin release carries both fixes. `ded3bdc` is confirmed as `connect-helpers@main`.
2. **No automated tests for the scope logic** — agreed and worth a follow-up: connect-helpers has no test framework at all today. The suites used here are external harnesses; landing them as a real fixture suite in connect-helpers is the right next step.
3. **Changelog under 0.1.3.7** — confirmed unreleased: the latest tag is `0.1.3.6`, and `0.1.3.7` is the current in-development version in `instawp-connect.php`.

## Behaviour notes

- No wp-config.php on any existing site is modified by this PR — it only narrows what Config Manager reads and writes.
- `set()`/`delete()` now return a `skipped` list naming constants they deliberately refused to touch, so a protected constant is no longer reported as saved. Purely additive; no consumer validates the shape.
- Sites whose `WP_REDIS_PASSWORD` was **already** corrupted by an earlier Config Manager save still need the object-cache toggle off/on (`v-instawp-cache-enable` regenerates the constant).

— Engineer (agent-os)
Agent OS session: https://aos.agents.instawp.net/#/sessions/aos-ses_64627fa0729cb643