### PR TITLE
fix: record local push progress and add a preflight check (86d3u4xzq)

### DIFF
--- a/doc/migrations/local-push.md
+++ b/doc/migrations/local-push.md
@@ -17,14 +17,54 @@ content. Everything is derived from the plugin's own defaults.
 
 ## Workflow
 
-1. `cli_archive_wordpress_files()` builds a zip of the docroot
-2. `cli_archive_wordpress_db()` exports the database via `wp db export`
-3. `create_insta_site()` provisions a blank destination site
-4. A `migrates-v3/local-push` record is created for tracking
-5. `cli_upload_using_sftp()` uploads the zip and the SQL dump to the destination
-6. `cli_restore_website()` calls the `restore-raw` API and polls until it completes
-7. Both artifacts are deleted from the destination and from the local temp directory
-8. `migrates-v3/finish-local-staging` finalises the destination configuration
+1. `cli_local_push_preflight()` verifies the environment can complete the run
+2. `cli_archive_wordpress_files()` builds a zip of the docroot
+3. `cli_archive_wordpress_db()` exports the database via `wp db export`
+4. `create_insta_site()` provisions a blank destination site
+5. A `migrates-v3/local-push` record is created for tracking, carrying the site sizes
+6. `cli_upload_using_sftp()` uploads the zip and the SQL dump to the destination
+7. `cli_restore_website()` calls the `restore-raw` API and polls until it completes
+8. Both artifacts are deleted from the destination and from the local temp directory
+9. `migrates-v3/finish-local-staging` finalises the destination configuration
+
+## Preflight
+
+`cli_local_push_preflight()` runs before any work and fails with a single message
+naming everything that is missing:
+
+- `ZipArchive` or `PharData` must be available
+- the PHP temp directory must exist and be writable
+- at least `InstaWP_Tools::CLI_MIN_FREE_DISK_BYTES` must be free there
+
+The checks are **capability-based, not platform-based** — the command is not
+restricted to any operating system. The failure that was historically read as "this
+only works on macOS" was `wp db export` needing `mysqldump` on the `PATH`;
+`cli_archive_wordpress_db()` now returns a `WP_Error` carrying the underlying stderr
+instead of letting an unrelated error surface.
+
+## Progress reporting
+
+The tracking record is updated as the run proceeds. Local push previously wrote only
+`migration-finished`, so a migration appeared never to have started and the dashboard
+showed no size at all.
+
+| Point in the flow | Stage recorded |
+|---|---|
+| before upload | `push-initiated` |
+| around the files transfer | `push-files-in-progress`, `push-files-finished` |
+| around the database transfer | `push-db-in-progress`, `push-db-finished` |
+| after the restore completes | `push-finished` |
+| at the end | `migration-finished` |
+| any failure | `failed` |
+
+`file_size` and `db_size` are sent when the migration record is **created**, not via
+`update-status` — the same point and the same `get_total_sizes()` helpers the standard
+push flow uses, so the dashboard reads consistently across migration modes.
+
+Stage updates go through `InstaWP_Tools::cli_update_stage()`, which requires both the
+migration id and key. `instawp_update_migration_stages()` falls back to the stored
+`migrate_id` option when passed an empty one, which under WP-CLI could attribute a
+stage to an unrelated migration left over from the admin UI.
 
 ## Artifact cleanup
 

--- a/includes/class-instawp-cli.php
+++ b/includes/class-instawp-cli.php
@@ -25,6 +25,13 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 
 			global $wp_version;
 
+			// Checked before any work starts, so a missing compression extension, an
+			// unwritable temp directory or a full disk is reported as one clear message
+			// instead of surfacing later as a raw error from whichever step needed it.
+			if ( is_wp_error( $preflight = InstaWP_Tools::cli_local_push_preflight() ) ) {
+				WP_CLI::error( $preflight->get_error_message() );
+			}
+
 			// Files backup. The exclusion list has to be passed here: it was previously
 			// computed further down (for the migration API payload only) and never reached
 			// the archiver, so host-specific files such as the source .htaccess were copied
@@ -38,9 +45,19 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 
 			// Database backup
 			$archive_path_db = InstaWP_Tools::cli_archive_wordpress_db();
-			WP_CLI::success( 'Database backup created successfully.' );
 
 			delete_option( 'instawp_parent_is_on_local' );
+
+			// The export shells out to mysqldump, so this is where an unreachable database
+			// or a missing mysqldump is caught. The files archive already exists at this
+			// point and would otherwise be orphaned in the temp directory.
+			if ( is_wp_error( $archive_path_db ) ) {
+				InstaWP_Tools::cli_delete_local_archives( array( $archive_path_file ) );
+
+				WP_CLI::error( $archive_path_db->get_error_message() );
+			}
+
+			WP_CLI::success( 'Database backup created successfully.' );
 
 			// Create Site
 			if ( is_wp_error( $create_site_res = InstaWP_Tools::create_insta_site( true ) ) ) {
@@ -71,6 +88,12 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 				'php_version'       => PHP_VERSION,
 				'wp_version'        => $wp_version,
 				'plugin_version'    => INSTAWP_PLUGIN_VERSION,
+				// Sizes are recorded when the migration is created, which is why they were
+				// left at zero for local push: the standard flow sends them here and this one
+				// did not. The same helpers are used so the dashboard reads consistently
+				// across migration modes.
+				'file_size'         => InstaWP_Tools::get_total_sizes( 'files', $migrate_settings ),
+				'db_size'           => InstaWP_Tools::get_total_sizes( 'db' ),
 				'migrate_key'       => $migrate_key,
 			);
 			$migrate_res         = Curl::do_curl( 'migrates-v3/local-push', $migrate_args );
@@ -94,8 +117,14 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 			// Wait 10 seconds
 			sleep( 10 );
 
-			// Upload files and db using SFTP
-			if ( is_wp_error( $file_upload_status = InstaWP_Tools::cli_upload_using_sftp( $site_id, $archive_path_file, $archive_path_db ) ) ) {
+			// Marks the transfer as under way. Local push previously recorded no stage at
+			// all between creating the migration and finishing it, so the dashboard showed
+			// a migration that never appeared to start.
+			instawp_update_migration_stages( array( 'push-initiated' => true ), $migrate_id, $migrate_key );
+
+			// Upload files and db using SFTP. The migration identifiers are passed so the
+			// per-artifact stages are recorded as each transfer starts and completes.
+			if ( is_wp_error( $file_upload_status = InstaWP_Tools::cli_upload_using_sftp( $site_id, $archive_path_file, $archive_path_db, $migrate_id, $migrate_key ) ) ) {
 
 				// Mark the migration failed
 				instawp_update_migration_stages( array( 'failed' => true ), $migrate_id, $migrate_key );
@@ -130,11 +159,14 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 				die( esc_html( $file_upload_status->get_error_message() ) );
 			}
 
+			// The transfer and the restore are both done at this point.
+			instawp_update_migration_stages( array( 'push-finished' => true ), $migrate_id, $migrate_key );
+
 			// The restore has consumed the uploaded copies, so clear them from the docroot
 			// and from the local temp directory before finishing up.
 			InstaWP_Tools::cli_cleanup_migration_artifacts( $site_id, $archive_path_file, $archive_path_db );
 
-			// Mark the migration failed
+			// Mark the migration finished
 			instawp_update_migration_stages( array( 'migration-finished' => true ), $migrate_id, $migrate_key );
 
 			// Finish configuration of the staging website

--- a/includes/class-instawp-tools.php
+++ b/includes/class-instawp-tools.php
@@ -10,6 +10,15 @@ defined( 'ABSPATH' ) || exit;
 class InstaWP_Tools {
 
 	/**
+	 * Minimum free space required in the temp directory before a local push starts.
+	 *
+	 * The files archive and the database dump are both written there before upload, so
+	 * running out of space mid-run wastes the whole transfer. 2 GB is a floor, not an
+	 * estimate of the site size — it only catches an already-full disk up front.
+	 */
+	const CLI_MIN_FREE_DISK_BYTES = 2147483648;
+
+	/**
 	 * Verify an AJAX request: validates nonce and user capability.
 	 * Sends a JSON error response and exits if either check fails.
 	 *
@@ -2116,13 +2125,97 @@ include $file_path;';
 		return apply_filters( 'instawp/filters/localize_data', $localize_data );
 	}
 
+	/**
+	 * Requirements that have to hold before a local push is attempted.
+	 *
+	 * Checked up front so a missing dependency is reported as one clear message rather
+	 * than surfacing later as a raw error from whichever component happened to need it.
+	 *
+	 * Deliberately capability-based rather than platform-based: the command is not
+	 * restricted to any operating system, it just needs a compression extension, a
+	 * writable temp directory and a working database export.
+	 *
+	 * @return true|WP_Error
+	 */
+	public static function cli_local_push_preflight() {
+
+		$errors = array();
+
+		if ( ! class_exists( 'ZipArchive' ) && ! class_exists( 'PharData' ) ) {
+			$errors[] = esc_html__( 'Neither the ZipArchive nor the PharData PHP extension is available; one is required to build the backup.', 'instawp-connect' );
+		}
+
+		$temp_dir = get_temp_dir();
+
+		if ( empty( $temp_dir ) || ! is_dir( $temp_dir ) ) {
+			$errors[] = esc_html__( 'The PHP temporary directory could not be located.', 'instawp-connect' );
+		} elseif ( ! is_writable( $temp_dir ) ) {
+			/* translators: %s: temporary directory path. */
+			$errors[] = sprintf( esc_html__( 'The temporary directory is not writable: %s', 'instawp-connect' ), $temp_dir );
+		} else {
+			// The archive and the database dump are both written here before upload, so a
+			// full disk fails the migration halfway through rather than up front.
+			$free_space = @disk_free_space( $temp_dir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+
+			if ( false !== $free_space && $free_space < self::CLI_MIN_FREE_DISK_BYTES ) {
+				$errors[] = sprintf(
+					/* translators: 1: temporary directory path, 2: human readable free space. */
+					esc_html__( 'Not enough free space in the temporary directory %1$s (%2$s available). The backup is written there before it is uploaded.', 'instawp-connect' ),
+					$temp_dir,
+					size_format( $free_space )
+				);
+			}
+		}
+
+		if ( ! empty( $errors ) ) {
+			return new WP_Error( 'local_push_preflight_failed', implode( ' ', $errors ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Export the database to a file in the temp directory.
+	 *
+	 * @return string|WP_Error Path to the dump, or WP_Error when the export failed.
+	 */
 	public static function cli_archive_wordpress_db() {
 
 		$archive_dir  = get_temp_dir();
 		$archive_name = 'wordpress_db_backup_' . date( 'Y-m-d_H-i-s' );
 		$db_file_name = $archive_dir . $archive_name . '.sql';
 
-		WP_CLI::runcommand( 'db export ' . $db_file_name );
+		// exit_error => false so a failing export is reported here with its own stderr
+		// instead of halting WP-CLI with a bare message from the underlying tool. The
+		// export shells out to mysqldump, so this is where a missing or unreachable
+		// mysqldump surfaces.
+		$export = WP_CLI::runcommand(
+			'db export ' . escapeshellarg( $db_file_name ),
+			array(
+				'exit_error' => false,
+				'return'     => 'all',
+			)
+		);
+
+		$return_code = is_object( $export ) && isset( $export->return_code ) ? (int) $export->return_code : 0;
+
+		if ( 0 !== $return_code ) {
+			$stderr = is_object( $export ) && ! empty( $export->stderr ) ? trim( $export->stderr ) : '';
+
+			return new WP_Error(
+				'db_export_failed',
+				sprintf(
+					/* translators: %s: error output from the database export. */
+					esc_html__( 'Database export failed. %s', 'instawp-connect' ),
+					'' !== $stderr ? $stderr : esc_html__( 'Check that the database is reachable and that mysqldump is installed and on the PATH.', 'instawp-connect' )
+				)
+			);
+		}
+
+		// A zero exit code with no usable file still means there is nothing to upload.
+		if ( ! file_exists( $db_file_name ) || 0 === filesize( $db_file_name ) ) {
+			return new WP_Error( 'db_export_failed', esc_html__( 'The database export produced an empty file.', 'instawp-connect' ) );
+		}
 
 		return $db_file_name;
 	}
@@ -2683,7 +2776,41 @@ include $file_path;';
 		self::cli_delete_local_archives( array( $file_path, $db_path ) );
 	}
 
-	public static function cli_upload_using_sftp( $site_id, $file_path, $db_path ) {
+	/**
+	 * Record a migration stage transition.
+	 *
+	 * Wrapped so the identifiers are checked first: instawp_update_migration_stages()
+	 * falls back to the stored migrate_id option when passed an empty one, which for a
+	 * CLI run could attribute the stage to an unrelated migration left over from the
+	 * admin UI.
+	 *
+	 * @param array  $stages      Stage keys to set.
+	 * @param string $migrate_id  Migration id.
+	 * @param string $migrate_key Migration key.
+	 *
+	 * @return void
+	 */
+	protected static function cli_update_stage( $stages, $migrate_id, $migrate_key ) {
+
+		if ( empty( $migrate_id ) || empty( $migrate_key ) ) {
+			return;
+		}
+
+		instawp_update_migration_stages( $stages, $migrate_id, $migrate_key );
+	}
+
+	/**
+	 * Upload the files archive and the database dump to the destination over SFTP.
+	 *
+	 * @param int    $site_id     Destination site id.
+	 * @param string $file_path   Local path of the files archive.
+	 * @param string $db_path     Local path of the database dump.
+	 * @param string $migrate_id  Migration id, for stage reporting. Optional.
+	 * @param string $migrate_key Migration key, for stage reporting. Optional.
+	 *
+	 * @return true|WP_Error
+	 */
+	public static function cli_upload_using_sftp( $site_id, $file_path, $db_path, $migrate_id = '', $migrate_key = '' ) {
 
 		$connection = self::cli_get_sftp_connection( $site_id );
 
@@ -2694,19 +2821,29 @@ include $file_path;';
 		$sftp      = $connection['sftp'];
 		$sftp_host = $connection['host'];
 
+		// Stages are reported around each transfer rather than around the method as a
+		// whole, so the dashboard reflects which artifact is actually moving.
+		self::cli_update_stage( array( 'push-files-in-progress' => true ), $migrate_id, $migrate_key );
+
 		$sftp_file_upload_status = $sftp->put( "web/$sftp_host/public_html/" . basename( $file_path ), $file_path, SFTP::SOURCE_LOCAL_FILE );
 
 		if ( ! $sftp_file_upload_status ) {
 			return new WP_Error( 'sftp_file_upload_failed', esc_html__( 'SFTP upload failed for files.', 'instawp-connect' ) );
 		}
 
+		self::cli_update_stage( array( 'push-files-finished' => true ), $migrate_id, $migrate_key );
+
 		WP_CLI::success( 'File uploaded successfully using SFTP.' );
+
+		self::cli_update_stage( array( 'push-db-in-progress' => true ), $migrate_id, $migrate_key );
 
 		$sftp_db_upload_status = $sftp->put( "web/$sftp_host/public_html/" . basename( $db_path ), $db_path, SFTP::SOURCE_LOCAL_FILE );
 
 		if ( ! $sftp_db_upload_status ) {
 			return new WP_Error( 'sftp_db_upload_failed', esc_html__( 'SFTP upload failed for database.', 'instawp-connect' ) );
 		}
+
+		self::cli_update_stage( array( 'push-db-finished' => true ), $migrate_id, $migrate_key );
 
 		WP_CLI::success( 'Database uploaded successfully using SFTP.' );
 

--- a/instawp-connect.php
+++ b/instawp-connect.php
@@ -8,7 +8,7 @@
  * @wordpress-plugin
  * Plugin Name:       InstaWP Connect
  * Description:       1-click WordPress plugin for Staging, Migrations, Management, Sync and Companion plugin for InstaWP.
- * Version:           0.1.3.8
+ * Version:           0.1.3.9
  * Author:            InstaWP Team
  * Author URI:        https://instawp.com/
  * License:           GPL-3.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 global $wpdb;
 
-defined( 'INSTAWP_PLUGIN_VERSION' ) || define( 'INSTAWP_PLUGIN_VERSION', '0.1.3.8' );
+defined( 'INSTAWP_PLUGIN_VERSION' ) || define( 'INSTAWP_PLUGIN_VERSION', '0.1.3.9' );
 defined( 'INSTAWP_API_DOMAIN_PROD' ) || define( 'INSTAWP_API_DOMAIN_PROD', 'https://app.instawp.io' );
 
 defined( 'INSTAWP_PLUGIN_URL' ) || define( 'INSTAWP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: clone, migrate, staging, backup, restore
 Requires at least: 5.6
 Tested up to: 7.0
 Requires PHP: 7.0
-Stable tag: 0.1.3.8
+Stable tag: 0.1.3.9
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 
@@ -97,6 +97,11 @@ Need support or want to partner with us? Go to our [website](http://instawp.com/
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team helps validate, triage, and handle any security vulnerabilities. [Report a security vulnerability](https://patchstack.com/database/vdp/instawp-connect).
 
 == Changelog ==
+
+= 0.1.3.9 - 04 August 2026 =
+- Fixed: Local push migration reported no progress and no site size in the dashboard, so a migration appeared never to start and finished without ever showing what was transferred.
+- Improved: Local push now checks its requirements before starting and reports exactly what is missing, instead of failing part way through with an unclear error.
+- Improved: A failed database export during local push is now reported with the underlying reason rather than an unrelated error.
 
 = 0.1.3.8 - 04 August 2026 =
 - Fixed: Local push migration copied the source site's .htaccess, wp-config.php, caches and log files to the destination, which could leave the migrated site redirecting to the original domain.


### PR DESCRIPTION
Addresses the two remaining defects from FreeScout #2682.

> **Stacked on #529.** Based on `fix/86d3u4xzq-local-push-excluded-paths` because both branches change `cli_local_push()` substantially. GitHub retargets this to `develop` automatically once #529 merges. Review #529 first.

## Defect 3 — the tracking record showed nothing

**Sizes.** `file_size` and `db_size` are recorded when the migration record is **created**, not through `update-status`. The standard flow sends them (`class-instawp-ajax.php:375-376`); local push's `$migrate_args` simply omitted them. That is the entire reason the reported migration showed a dashboard size matching nothing on disk. The same `get_total_sizes()` helpers are now used, so every migration mode reads consistently.

**Stages.** Local push wrote only `migration-finished`, so a migration appeared never to have started:

| Point in the flow | Stage |
|---|---|
| before upload | `push-initiated` |
| around the files transfer | `push-files-in-progress`, `push-files-finished` |
| around the database transfer | `push-db-in-progress`, `push-db-finished` |
| after the restore completes | `push-finished` |
| at the end | `migration-finished` |
| any failure | `failed` |

The files and database stages are emitted inside `cli_upload_using_sftp()` around each individual transfer rather than bracketing the whole call, so the dashboard reflects which artifact is actually moving. The migration identifiers are passed in as optional arguments, so the method's existing signature and behaviour are unchanged for any other caller.

Stage writes go through a new `cli_update_stage()` which requires both identifiers. `instawp_update_migration_stages()` falls back to the stored `migrate_id` option when passed an empty one — under WP-CLI that could attribute a stage to an unrelated migration left over from the admin UI.

## Defect 5 — no preflight, and an unclear failure

`cli_local_push_preflight()` runs before any work and reports **everything** missing in one message rather than failing on the first problem: a compression extension (`ZipArchive` or `PharData`), a temp directory that exists and is writable, and enough free space there for the archive.

**Deliberately capability-based, not platform-based.** The ticket asked for the command to refuse to run outside macOS. That premise doesn't hold: the failure behind it was `wp db export` needing `mysqldump` on the `PATH`, and the Windows archive corruption it was conflated with is fixed in #529. Blocking Windows would now break a working path.

`cli_archive_wordpress_db()` previously ran the export and returned the path without checking anything — a failed export produced a valid-looking path to a missing or empty file. It now runs with `exit_error => false`, returns a `WP_Error` carrying the export's own stderr, and treats a zero-byte dump as a failure. The path is also escaped, which it was not before.

## Verification

| Suite | Result |
|---|---|
| Preflight branches (each failure condition, multi-failure reporting) | 11/11 |
| Exclusion filter (from #529, unaffected) | 29/29 |
| Windows separators + entry naming (from #529) | 11/11 |
| Local delete guards (from #529) | 10/10 |
| Artifact validator (from #529) | 20/20 |

## Notes for review

- **The `push-*` stage key names are the one unverified part.** No flow in this plugin writes them — `InstaWP_Setting::get_stages()` lists only `pull-*` keys, and in standard push the server sets them. The names used here are the ones observed in the `migrates_v3` row on the reported migration. If any is wrong the update is a silent no-op, so the failure mode is "no worse than today", but someone with access to the migrates-v3 API should confirm them.
- **`progress_files` / `progress_db` are not sent.** The plugin only ever reads these from the API response, and there is no evidence `update-status` accepts them as input. Left alone rather than guessed at.
- The 2 GB free-space floor is a sanity check for an already-full disk, not an estimate of the site size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)