### PR TITLE
fix: require a valid token for sync media downloads (86d406d23)

### DIFF
--- a/doc/two-way-sync.md
+++ b/doc/two-way-sync.md
@@ -46,6 +46,30 @@ Activity logging captures all changes on connected sites. Events are recorded an
 | GET | `/instawp-connect/v1/sync/summary` | Event summary |
 | POST | `/instawp-connect/v1/sync/download-media` | Download media files |
 
+### `sync/download-media` authorization
+
+This endpoint streams raw attachment bytes to the paired site, so it is gated harder than the
+event endpoints. `InstaWP_Sync_Apis::validate_sync_api_request()` runs both as the route's
+`permission_callback` and again at the top of the callback, and denies the request unless:
+
+1. The request carries `Authorization: Bearer <hash>` or `X-IWP-AUTH: <hash>`, where
+   `<hash>` is `sha256( connect_id . '_' . connect_uuid )` of the site being called.
+   The caller builds these headers with `instawp_get_migration_headers()`.
+2. The site is connected — `instawp_api_options` holds both `connect_id` and `connect_uuid`.
+3. The token matches the locally derived hash (`hash_equals()`).
+
+The `instawp_is_event_syncing` toggle is deliberately **not** part of this check. The peer site
+requests media while it processes events, which can happen after the toggle was switched off on
+this side, so gating on it would break legitimate syncs.
+
+Every denial returns a `WP_Error` — never a `WP_REST_Response`. A permission callback that
+returns anything other than `true`, `false`, `null` or `WP_Error` is read as "authorized" by
+`WP_REST_Server`, which is how CVE-class issue 86d406d23 allowed unauthenticated media
+downloads when the auth header was omitted.
+
+The callback additionally requires the requested ID to be an `attachment` post and the resolved
+file to sit inside the uploads directory, and it only serves the extensions in its allowlist.
+
 ## Features
 
 - Event filtering by type (posts, users, plugins, etc.)

--- a/includes/sync/class-instawp-sync-apis.php
+++ b/includes/sync/class-instawp-sync-apis.php
@@ -136,68 +136,97 @@ class InstaWP_Sync_Apis extends InstaWP_Rest_Api {
 	public function download_media( WP_REST_Request $request ) {
 		// Defence in depth: validate again inside the callback so a future change to the
 		// route registration or to the permission callback cannot expose media files.
+		// Kept outside the try block so an authorization failure can never be swallowed.
 		$validated = $this->validate_sync_api_request( $request );
 		if ( is_wp_error( $validated ) ) {
 			// Returned as is, WordPress converts it into the proper HTTP error response.
 			return $validated;
 		}
 
-		// Get media_url from the request
-		$media_id = $request->get_param('media_id');
-		if ( empty( $media_id ) || ! is_numeric( $media_id ) || 1 > intval( $media_id ) ) {
-			return $this->send_response( array(
-				'success' => false,
-				'message' => __( 'Empty or invalid media id.', 'instawp-connect' ),
-			) );
-		}
+		// Everything from here up to the transfer only prepares the file, so a failure can
+		// still be reported as a normal response. The transfer itself stays outside.
+		try {
+			// Get media_url from the request
+			$media_id = $request->get_param('media_id');
+			if ( empty( $media_id ) || ! is_numeric( $media_id ) || 1 > intval( $media_id ) ) {
+				return $this->send_response( array(
+					'success' => false,
+					'message' => __( 'Empty or invalid media id.', 'instawp-connect' ),
+				) );
+			}
 
-		$media_id = intval( $media_id );
+			$media_id = intval( $media_id );
 
-		// Only real attachments may be served. get_attached_file() also resolves any other
-		// post type that happens to carry _wp_attached_file meta.
-		if ( 'attachment' !== get_post_type( $media_id ) ) {
+			// Only real attachments may be served. get_attached_file() also resolves any other
+			// post type that happens to carry _wp_attached_file meta.
+			if ( 'attachment' !== get_post_type( $media_id ) ) {
+				return $this->send_response( array(
+					'success' => false,
+					'message' => __( 'File not found.', 'instawp-connect' ),
+				) );
+			}
+
+			$file_path = get_attached_file( $media_id ); // Full path
+			if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
+				return $this->send_response( array(
+					'success' => false,
+					'message' => __( 'File not found.', 'instawp-connect' ),
+				) );
+			}
+
+			// Keep the served file inside the uploads directory. _wp_attached_file can hold an
+			// absolute path, so a tampered meta value could otherwise point anywhere on disk.
+			// The comparison stays lexical on purpose: resolving symlinks would break sites that
+			// symlink an uploads sub folder to shared media, and placing a symlink inside uploads
+			// already needs filesystem access, which makes this endpoint pointless to an attacker.
+			$upload_dir      = wp_get_upload_dir();
+			$upload_base_dir = empty( $upload_dir['basedir'] ) ? '' : wp_normalize_path( $upload_dir['basedir'] );
+			$normalized_path = wp_normalize_path( $file_path );
+
+			if ( empty( $upload_base_dir ) || false !== strpos( $normalized_path, '../' ) || 0 !== strpos( $normalized_path, trailingslashit( $upload_base_dir ) ) ) {
+				// Logged locally because the file does exist, the caller keeps the generic
+				// message so the response can not be used to probe which media ids exist.
+				Helper::add_error_log( array(
+					'title'   => 'instawp: sync download-media rejected a file outside the uploads directory',
+					'message' => $normalized_path,
+				) );
+
+				return $this->send_response( array(
+					'success' => false,
+					'message' => __( 'File not found.', 'instawp-connect' ),
+				) );
+			}
+
+			$file_type_ext = wp_check_filetype( $file_path );
+
+			if ( false === $file_type_ext['type'] || empty( $file_type_ext['ext'] ) || ! in_array( $file_type_ext['ext'], array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'mp4', 'pdf', 'doc', 'docx', 'xls', 'xlsx', 'csv', 'txt', 'rtf', 'html', 'zip', 'mp3', 'wma', 'mpg', 'flv', 'avi' ) ) ) {
+				return $this->send_response( array(
+					'success' => false,
+					'message' => __( 'File type not supported.', 'instawp-connect' ),
+				) );
+			}
+
+			// Discard anything already buffered (notices, BOM) so the file bytes stay intact.
+			// Bounded like wp_ob_end_flush_all(): a buffer that can not be removed, for example
+			// with zlib.output_compression on, keeps ob_get_level() unchanged and would otherwise
+			// spin until the request times out.
+			$ob_levels = ob_get_level();
+			for ( $i = 0; $i < $ob_levels; $i ++ ) {
+				if ( ! @ob_end_clean() ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+					break;
+				}
+			}
+		} catch ( \Throwable $th ) {
+			Helper::add_error_log( array( 'title' => 'instawp: sync download-media failed' ), $th );
+
 			return $this->send_response( array(
 				'success' => false,
 				'message' => __( 'File not found.', 'instawp-connect' ),
 			) );
 		}
 
-		$file_path = get_attached_file( $media_id ); // Full path
-		if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
-			return $this->send_response( array(
-				'success' => false,
-				'message' => __( 'File not found.', 'instawp-connect' ),
-			) );
-		}
-
-		// Keep the served file inside the uploads directory. _wp_attached_file can hold an
-		// absolute path, so a tampered meta value could otherwise point anywhere on disk.
-		$upload_dir      = wp_get_upload_dir();
-		$upload_base_dir = empty( $upload_dir['basedir'] ) ? '' : wp_normalize_path( $upload_dir['basedir'] );
-		$normalized_path = wp_normalize_path( $file_path );
-
-		if ( empty( $upload_base_dir ) || false !== strpos( $normalized_path, '../' ) || 0 !== strpos( $normalized_path, trailingslashit( $upload_base_dir ) ) ) {
-			return $this->send_response( array(
-				'success' => false,
-				'message' => __( 'File not found.', 'instawp-connect' ),
-			) );
-		}
-
-		$file_type_ext = wp_check_filetype( $file_path );
-
-		if ( false === $file_type_ext['type'] || empty( $file_type_ext['ext'] ) || ! in_array( $file_type_ext['ext'], array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'mp4', 'pdf', 'doc', 'docx', 'xls', 'xlsx', 'csv', 'txt', 'rtf', 'html', 'zip', 'mp3', 'wma', 'mpg', 'flv', 'avi' ) ) ) {
-			return $this->send_response( array(
-				'success' => false,
-				'message' => __( 'File type not supported.', 'instawp-connect' ),
-			) );
-		}
-
-		// Discard anything already buffered (notices, BOM) so the file bytes stay intact.
-		while ( ob_get_level() > 0 ) {
-			ob_end_clean();
-		}
-
-		// Serve the file for download
+		// Serve the file for download. Left outside the try block on purpose: once the headers
+		// and the first bytes are out there is nothing left to recover into a response.
 		header('Content-Description: File Transfer');
 		header('Content-Type: ' . $file_type_ext['type'] );
 		header('Content-Disposition: attachment; filename="' . basename( $file_path ) . '"');
@@ -205,7 +234,7 @@ class InstaWP_Sync_Apis extends InstaWP_Rest_Api {
 		header('Cache-Control: must-revalidate');
 		header('Pragma: public');
 		header('Content-Length: ' . filesize( $file_path ));
-	
+
 		readfile( $file_path );
 		exit;
 	}

--- a/includes/sync/class-instawp-sync-apis.php
+++ b/includes/sync/class-instawp-sync-apis.php
@@ -70,6 +70,25 @@ class InstaWP_Sync_Apis extends InstaWP_Rest_Api {
 	}
 
 	/**
+	 * Build an authorization WP_Error suitable for a permission callback.
+	 *
+	 * A permission callback must return true, false, null or a WP_Error. Any other
+	 * return value (a WP_REST_Response included) is treated as "authorized" by
+	 * WP_REST_Server, so every denial path has to hand back a real WP_Error with an
+	 * explicit HTTP status attached.
+	 *
+	 * @param string $message Error message to expose to the caller.
+	 * @param int    $status  Optional HTTP status code. Defaults to 401/403 based on login state.
+	 *
+	 * @return WP_Error
+	 */
+	private function sync_api_error( $message, $status = 0 ) {
+		$status = empty( $status ) ? rest_authorization_required_code() : intval( $status );
+
+		return new WP_Error( 'instawp_sync_rest_forbidden', $message, array( 'status' => $status ) );
+	}
+
+	/**
 	 * Valid api request and if invalid api key then stop executing.
 	 *
 	 * @param WP_REST_Request $request
@@ -79,24 +98,30 @@ class InstaWP_Sync_Apis extends InstaWP_Rest_Api {
 	public function validate_sync_api_request( WP_REST_Request $request ) {
 		// Get bearer token from the request
 		$bearer_token = $this->get_bearer_token( $request );
-		// Check if the bearer token is a wp error
+		// A missing or empty token must deny the request. The WP_Error has to be returned
+		// as is, wrapping it in a WP_REST_Response would authorize the request instead.
 		if ( is_wp_error( $bearer_token ) ) {
-			return $this->throw_error( $bearer_token );
+			return $this->sync_api_error( $bearer_token->get_error_message() );
 		}
 
 		$instawp_api_options = get_option( 'instawp_api_options' );
 
-		// check if the bearer token is empty
+		// Without connect details there is no shared secret to compare the token against.
 		if ( empty( $instawp_api_options ) || empty( $instawp_api_options['connect_id'] ) || empty( $instawp_api_options['connect_uuid'] ) ) {
-			return new WP_Error( 401, esc_html__( 'Empty API options.', 'instawp-connect' ) );
+			return $this->sync_api_error( esc_html__( 'Empty API options.', 'instawp-connect' ) );
 		}
 
 		// Prepare hash
 		$hash = hash( 'sha256', $instawp_api_options['connect_id'] . '_' . $instawp_api_options['connect_uuid'] );
 
-		if ( ! hash_equals( $bearer_token, $hash ) ) {
-			return new WP_Error( 401, esc_html__( 'Incorrect token.', 'instawp-connect' ) );
+		// Known value first, user supplied value second, as hash_equals() expects.
+		if ( ! hash_equals( $hash, $bearer_token ) ) {
+			return $this->sync_api_error( esc_html__( 'Incorrect token.', 'instawp-connect' ) );
 		}
+
+		// Note: the instawp_is_event_syncing toggle is intentionally NOT checked here. Media is
+		// requested by the peer site while it processes events, which can happen after the toggle
+		// has been switched off on this side, so gating on it would break legitimate syncs.
 
 		return true;
 	}
@@ -109,6 +134,14 @@ class InstaWP_Sync_Apis extends InstaWP_Rest_Api {
 	 * @return WP_REST_Response
 	 */
 	public function download_media( WP_REST_Request $request ) {
+		// Defence in depth: validate again inside the callback so a future change to the
+		// route registration or to the permission callback cannot expose media files.
+		$validated = $this->validate_sync_api_request( $request );
+		if ( is_wp_error( $validated ) ) {
+			// Returned as is, WordPress converts it into the proper HTTP error response.
+			return $validated;
+		}
+
 		// Get media_url from the request
 		$media_id = $request->get_param('media_id');
 		if ( empty( $media_id ) || ! is_numeric( $media_id ) || 1 > intval( $media_id ) ) {
@@ -117,10 +150,33 @@ class InstaWP_Sync_Apis extends InstaWP_Rest_Api {
 				'message' => __( 'Empty or invalid media id.', 'instawp-connect' ),
 			) );
 		}
-		
+
 		$media_id = intval( $media_id );
+
+		// Only real attachments may be served. get_attached_file() also resolves any other
+		// post type that happens to carry _wp_attached_file meta.
+		if ( 'attachment' !== get_post_type( $media_id ) ) {
+			return $this->send_response( array(
+				'success' => false,
+				'message' => __( 'File not found.', 'instawp-connect' ),
+			) );
+		}
+
 		$file_path = get_attached_file( $media_id ); // Full path
 		if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
+			return $this->send_response( array(
+				'success' => false,
+				'message' => __( 'File not found.', 'instawp-connect' ),
+			) );
+		}
+
+		// Keep the served file inside the uploads directory. _wp_attached_file can hold an
+		// absolute path, so a tampered meta value could otherwise point anywhere on disk.
+		$upload_dir      = wp_get_upload_dir();
+		$upload_base_dir = empty( $upload_dir['basedir'] ) ? '' : wp_normalize_path( $upload_dir['basedir'] );
+		$normalized_path = wp_normalize_path( $file_path );
+
+		if ( empty( $upload_base_dir ) || false !== strpos( $normalized_path, '../' ) || 0 !== strpos( $normalized_path, trailingslashit( $upload_base_dir ) ) ) {
 			return $this->send_response( array(
 				'success' => false,
 				'message' => __( 'File not found.', 'instawp-connect' ),
@@ -134,6 +190,11 @@ class InstaWP_Sync_Apis extends InstaWP_Rest_Api {
 				'success' => false,
 				'message' => __( 'File type not supported.', 'instawp-connect' ),
 			) );
+		}
+
+		// Discard anything already buffered (notices, BOM) so the file bytes stay intact.
+		while ( ob_get_level() > 0 ) {
+			ob_end_clean();
 		}
 
 		// Serve the file for download

--- a/includes/sync/class-instawp-sync-apis.php
+++ b/includes/sync/class-instawp-sync-apis.php
@@ -143,8 +143,9 @@ class InstaWP_Sync_Apis extends InstaWP_Rest_Api {
 			return $validated;
 		}
 
-		// Everything from here up to the transfer only prepares the file, so a failure can
-		// still be reported as a normal response. The transfer itself stays outside.
+		// Preparing the file and serving it both run under the guard below. A failure while
+		// preparing still becomes a normal response, a failure once the transfer started can
+		// only end the request, which is what the headers_sent() check in the catch does.
 		try {
 			// Get media_url from the request
 			$media_id = $request->get_param('media_id');

--- a/includes/sync/class-instawp-sync-apis.php
+++ b/includes/sync/class-instawp-sync-apis.php
@@ -216,27 +216,33 @@ class InstaWP_Sync_Apis extends InstaWP_Rest_Api {
 					break;
 				}
 			}
+
+			// Serve the file for download
+			header('Content-Description: File Transfer');
+			header('Content-Type: ' . $file_type_ext['type'] );
+			header('Content-Disposition: attachment; filename="' . basename( $file_path ) . '"');
+			header('Expires: 0');
+			header('Cache-Control: must-revalidate');
+			header('Pragma: public');
+			header('Content-Length: ' . filesize( $file_path ));
+
+			readfile( $file_path );
+			exit;
 		} catch ( \Throwable $th ) {
 			Helper::add_error_log( array( 'title' => 'instawp: sync download-media failed' ), $th );
+
+			// If the transfer already started, the headers and part of the body are out and the
+			// peer is reading binary. Appending a JSON error would only corrupt what it receives,
+			// so the request is ended instead and the peer sees a truncated download.
+			if ( headers_sent() ) {
+				exit;
+			}
 
 			return $this->send_response( array(
 				'success' => false,
 				'message' => __( 'File not found.', 'instawp-connect' ),
 			) );
 		}
-
-		// Serve the file for download. Left outside the try block on purpose: once the headers
-		// and the first bytes are out there is nothing left to recover into a response.
-		header('Content-Description: File Transfer');
-		header('Content-Type: ' . $file_type_ext['type'] );
-		header('Content-Disposition: attachment; filename="' . basename( $file_path ) . '"');
-		header('Expires: 0');
-		header('Cache-Control: must-revalidate');
-		header('Pragma: public');
-		header('Content-Length: ' . filesize( $file_path ));
-
-		readfile( $file_path );
-		exit;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 - Improved: Local push reports progress and site size, and reports backup failures more clearly.
 - Fixed: Local push from Windows now transfers files correctly.
 - Security: Hardened cleanup of temporary migration files.
+- Security: Hardened authentication and file handling for two-way sync media transfers.
 
 = 0.1.3.7 - 03 August 2026 =
 - Security: Hardened the handling and cleanup of temporary migration files.


### PR DESCRIPTION
## Issue

[86d406d23](https://app.clickup.com/t/1868024/86d406d23) — Patchstack report, CVSS 5.3, broken access control.

`POST /wp-json/instawp-connect/v1/sync/download-media` served attachment bytes to unauthenticated callers when the auth header was **omitted**. A request carrying a *wrong* token was correctly denied, which is what made the report look odd at first.

## Root cause

The route uses `validate_sync_api_request()` as its `permission_callback`. The missing-token branch returned `throw_error()`, which wraps the error in a **`WP_REST_Response`**:

```php
if ( is_wp_error( $bearer_token ) ) {
    return $this->throw_error( $bearer_token );   // returns WP_REST_Response
}
```

`WP_REST_Server` only treats `WP_Error`, `false` and `null` as denied — anything else is read as authorized, so the callback ran and streamed the file. The other two branches returned a raw `WP_Error` and denied properly, hence the asymmetry.

This was the only route in the plugin with a non-`__return_true` permission callback, so nothing else was affected. The five other `throw_error()` calls in the file are inside route callbacks, which is correct usage.

## Changes

- Every denial path now returns a `WP_Error` with an explicit HTTP status, via a new `sync_api_error()` helper.
- `download_media()` re-validates internally, so a future change to the route registration or permission callback cannot expose media again.
- Only `attachment` posts are served, and the resolved path must sit inside the uploads directory (`_wp_attached_file` can hold an absolute path).
- Buffered output is discarded before `readfile()` so the bytes stay intact.
- `hash_equals()` argument order corrected (known value first).
- `doc/two-way-sync.md` documents the auth contract; `readme.txt` gets a changelog line under the existing 0.1.3.8 Beta section. No version bump — 0.1.3.8 is unreleased and this ships under it.

The `instawp_is_event_syncing` toggle is deliberately **not** gated here: the peer site fetches media while processing events, which can happen after the toggle was switched off on this side, so gating on it would break legitimate syncs. A comment records this so it is not re-added.

## Verification

Tested on a local InstaCP site with the plugin symlinked to this branch, `php -l` clean.

| Request | Before | After |
|---|---|---|
| No auth header | **200**, file bytes | **401** `Empty bearer token.` |
| `Authorization: Bearer invalid` | 401 | **401** `Incorrect token.` |
| Valid token, sync toggle off | 200 | **200**, 1,087,845-byte JPEG intact |
| Valid token, `X-IWP-AUTH` header | 200 | **200** |
| Valid token, non-attachment post ID | `File not found.` | **400** `File not found.` |

The pre-fix behaviour was reproduced on a second local site running the released plugin: an unauthenticated POST returned `200 OK`, `Content-Disposition: attachment; filename="…unsplash.jpg"`, 470,268 bytes of JPEG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpEAdjxqKt21XvtGzY1Aop