### PR TITLE
docs: mark 0.1.3.8 changelog as released (12 August 2026)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -98,7 +98,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
-= 0.1.3.8 - Beta =
+= 0.1.3.8 - 12 August 2026 =
 - Improved: Local push no longer copies host-specific configuration, caches, logs, or build and version control folders to the destination.
 - Improved: Local push reports progress and site size, and reports backup failures more clearly.
 - Fixed: Local push from Windows now transfers files correctly.


### PR DESCRIPTION
Replaces the `Beta` tag on the `= 0.1.3.8 =` changelog section in `readme.txt` with the release date, **12 August 2026**.

Documentation-only, one line:

```diff
-= 0.1.3.8 - Beta =
+= 0.1.3.8 - 12 August 2026 =
```

No version-number change — `instawp-connect.php` and `Stable tag:` already read `0.1.3.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpEAdjxqKt21XvtGzY1Aop