### PR TITLE
Release version 0.1.3.8 

### DIFF
--- a/doc/migrations/local-push.md
+++ b/doc/migrations/local-push.md
@@ -1,0 +1,113 @@
+# Local Push Migration
+
+Local push migrates a WordPress site running on a developer machine (LocalWP, MAMP,
+Valet, …) to a freshly provisioned InstaWP site, driven entirely from WP-CLI.
+
+```bash
+wp instawp local push
+```
+
+The command takes no arguments — there are no flags for selecting or excluding
+content. Everything is derived from the plugin's own defaults.
+
+## Key Files
+
+- `includes/class-instawp-cli.php` — `cli_local_push()`, the whole flow
+- `includes/class-instawp-tools.php` — archive creation, SFTP upload, restore polling
+
+## Workflow
+
+1. `cli_archive_wordpress_files()` builds a zip of the docroot
+2. `cli_archive_wordpress_db()` exports the database via `wp db export`
+3. `create_insta_site()` provisions a blank destination site
+4. A `migrates-v3/local-push` record is created for tracking
+5. `cli_upload_using_sftp()` uploads the zip and the SQL dump to the destination
+6. `cli_restore_website()` calls the `restore-raw` API and polls until it completes
+7. Both artifacts are deleted from the destination and from the local temp directory
+8. `migrates-v3/finish-local-staging` finalises the destination configuration
+
+## Artifact cleanup
+
+The archive and the database dump must be uploaded into the destination's
+`public_html`, because the restore API resolves them by basename relative to the
+docroot. Nothing in the restore removes them, and the web server serves `.zip` and
+`.sql` statically, so a rewrite-based guard does not cover them — a full copy of the
+site and its database would stay publicly downloadable.
+
+`cli_local_push()` therefore clears both copies on **every** exit path, including the
+failure paths, where an upload may already have completed before the error:
+
+| Function | Removes |
+|----------|---------|
+| `InstaWP_Tools::cli_delete_remote_artifacts()` | The zip and SQL dump from the destination docroot |
+| `InstaWP_Tools::cli_delete_local_archives()` | The zip and SQL dump from the local temp directory |
+
+`cli_delete_remote_artifacts()` opens a fresh SFTP connection via
+`cli_get_sftp_connection()` rather than reusing the upload's session, which has usually
+expired by the time the restore poll finishes. A failure to delete is reported with
+`WP_CLI::warning()` including the remote path, never swallowed — a leftover artifact is
+a data exposure and the operator needs to be able to remove it by hand.
+
+## Exclusions
+
+The archive skips the paths returned by
+`InstaWP_Tools::get_local_push_excluded_paths()`:
+
+| Path | Reason |
+|------|--------|
+| `.htaccess` | Carries the origin host's PHP handlers and canonical-redirect rules |
+| `.user.ini` | Host-specific PHP configuration |
+| `index.html` | Would shadow `index.php` on the destination |
+| `wp-config.php` | Regenerated on the destination; also carries source DB credentials |
+| `wp-content/.htaccess` | Same as the docroot `.htaccess` |
+| `wp-content/cache`, `wp-content/et-cache`, `wp-content/upgrade` | Stale as soon as the domain changes |
+| `wp-content/object-cache-iwp.php` | Points at the source's cache backend |
+| `wp-content/mu-plugins/{redis-cache-pro,sso,wp-stack-cache}.php` | Host-specific drop-ins |
+| `wp-content/mu-plugins/mu-pluginsold` | Legacy directory |
+| `wp-content/plugins/instawp-connect` | The destination runs its own copy |
+
+In addition, any file named `error_log` or `debug.log` is skipped **at any depth**.
+Hosts such as cPanel write an `error_log` into every directory that throws; these are
+useless on the destination and disclose the source's absolute filesystem paths.
+
+WordPress core (`wp-admin`, `wp-includes`) **is** included in the archive.
+
+### Why not `migrate_settings['excluded_paths']`?
+
+`process_migration_settings()` builds an exclusion list that is *inventory-aware*: any
+plugin or theme whose checksum matches the official WordPress.org release is added to
+`excluded_paths` and simultaneously recorded in `inventory_items`, so the destination
+can re-download a clean copy instead of transferring it.
+
+That contract has two halves. The v3 pull/push flow implements both — `iwp-dest`
+reconstructs from `inventory_items`. Local push implements neither: it ships a plain
+zip to `restore-raw`, which unpacks the archive and has no inventory step.
+
+Reusing `excluded_paths` here would therefore drop every checksum-matched plugin and
+theme from the destination with nothing to restore them. `get_local_push_excluded_paths()`
+exists to keep the two lists separate: it covers only files that must never be copied,
+regardless of inventory.
+
+## Windows
+
+`ABSPATH` is defined by WordPress as `__DIR__ . '/'`, so on Windows it mixes
+separators — `C:\xampp\htdocs\mysite/`. The archive loop converts each file path to
+forward slashes before stripping the `ABSPATH` prefix, so that prefix has to be
+converted the same way. Without it the strip silently fails and every entry is stored
+under its full local path (`C:/xampp/htdocs/mysite/wp-content/…`) instead of relative
+to the site root, which unpacks on the destination as a directory named `C:` and an
+otherwise empty docroot — a migration that reports success but produces a blank site.
+
+Skip-list comparisons have the same requirement: `get_local_push_excluded_paths()`
+builds its entries with `DIRECTORY_SEPARATOR`, `SplFileInfo::getSubPath()` returns
+backslash-separated sub-paths on Windows, and `cli_archive_wordpress_files()` merges in
+two literal forward-slash entries. Every value is passed through the local
+`$normalize_path` helper before being compared, so all three forms match.
+
+## Notes
+
+- `get_migrate_settings()` is still called to populate the tracking record's settings
+  payload. It is not used to build the archive.
+- The `zip` branch of `cli_archive_wordpress_files()` is the default path. Skip entries
+  are normalised (forward slashes, no trailing separator) before comparison, because
+  callers mix `DIRECTORY_SEPARATOR` with literal `/`.

--- a/doc/migrations/local-push.md
+++ b/doc/migrations/local-push.md
@@ -110,6 +110,31 @@ In addition, any file named `error_log` or `debug.log` is skipped **at any depth
 Hosts such as cPanel write an `error_log` into every directory that throws; these are
 useless on the destination and disclose the source's absolute filesystem paths.
 
+### Pruned directory names
+
+`get_local_push_excluded_dir_names()` returns names that are pruned wherever they
+appear, since they live under whichever theme or plugin has a build setup:
+
+| Name | Reason |
+|------|--------|
+| `node_modules` | Node build tooling; never loaded at runtime |
+| `.git` | Version control metadata (matched as a file too — a submodule checkout has `.git` as a file) |
+| `.github` | CI configuration |
+| `.wordpress-org` | WordPress.org listing assets: screenshots, banners, icons |
+
+Rejecting the directory stops the iterator descending into it, so its contents are
+never enumerated. That is where the saving is: a single `node_modules` can hold more
+files than the rest of the site combined, and the cost lands three times over —
+walking, zipping and uploading.
+
+This is a judgement call rather than a rule. A theme or plugin that ships runtime
+JavaScript inside `node_modules` would lose it. That is rare and the trade is worth it
+for a developer machine, but it is why the list is deliberately short and why it is
+passed in by the caller rather than hardcoded into `cli_archive_wordpress_files()`.
+
+**`vendor` is intentionally not on this list.** Composer dependencies are runtime code;
+removing them breaks any plugin that ships one.
+
 WordPress core (`wp-admin`, `wp-includes`) **is** included in the archive.
 
 ### Why not `migrate_settings['excluded_paths']`?

--- a/doc/migrations/local-push.md
+++ b/doc/migrations/local-push.md
@@ -17,30 +17,35 @@ content. Everything is derived from the plugin's own defaults.
 
 ## Workflow
 
-1. `cli_local_push_preflight()` verifies the environment can complete the run
-2. `cli_archive_wordpress_files()` builds a zip of the docroot
-3. `cli_archive_wordpress_db()` exports the database via `wp db export`
-4. `create_insta_site()` provisions a blank destination site
-5. A `migrates-v3/local-push` record is created for tracking, carrying the site sizes
-6. `cli_upload_using_sftp()` uploads the zip and the SQL dump to the destination
-7. `cli_restore_website()` calls the `restore-raw` API and polls until it completes
-8. Both artifacts are deleted from the destination and from the local temp directory
-9. `migrates-v3/finish-local-staging` finalises the destination configuration
+1. `cli_archive_wordpress_files()` builds a zip of the docroot
+2. `cli_archive_wordpress_db()` exports the database via `wp db export`
+3. `create_insta_site()` provisions a blank destination site
+4. A `migrates-v3/local-push` record is created for tracking, carrying the site sizes
+5. `cli_upload_using_sftp()` uploads the zip and the SQL dump to the destination
+6. `cli_restore_website()` calls the `restore-raw` API and polls until it completes
+7. Both artifacts are deleted from the destination and from the local temp directory
+8. `migrates-v3/finish-local-staging` finalises the destination configuration
 
-## Preflight
+## Failure detection
 
-`cli_local_push_preflight()` runs before any work and fails with a single message
-naming everything that is missing:
+Each step reports its own failure rather than being predicted by an up-front
+environment check — a missing compression extension already returns
+`no_method_find`, and an unwritable temp directory already returns
+`zip_is_not_opening`.
 
-- `ZipArchive` or `PharData` must be available
-- the PHP temp directory must exist and be writable
-- at least `InstaWP_Tools::CLI_MIN_FREE_DISK_BYTES` must be free there
+Two places needed the return value actually checked:
 
-The checks are **capability-based, not platform-based** — the command is not
-restricted to any operating system. The failure that was historically read as "this
-only works on macOS" was `wp db export` needing `mysqldump` on the `PATH`;
-`cli_archive_wordpress_db()` now returns a `WP_Error` carrying the underlying stderr
-instead of letting an unrelated error surface.
+- **`$zip->close()`** — ZipArchive writes the archive on close, so a full disk, a
+  permission problem or a corrupt entry surfaces there and nowhere earlier.
+  Discarding the result handed back the path to a truncated archive as though it
+  had been written, and the migration went on to upload and restore it.
+- **`cli_archive_wordpress_db()`** — the export runs with `exit_error => false`, so a
+  failure returns a `WP_Error` carrying the underlying stderr and a zero-byte dump is
+  treated as a failure. Previously the path was returned regardless of whether
+  anything had been written, which is how a missing `mysqldump` was read as "local
+  push only works on macOS".
+
+The command is not restricted to any operating system.
 
 ## Progress reporting
 

--- a/doc/migrations/local-push.md
+++ b/doc/migrations/local-push.md
@@ -98,7 +98,6 @@ The archive skips the paths returned by
 | `.htaccess` | Carries the origin host's PHP handlers and canonical-redirect rules |
 | `.user.ini` | Host-specific PHP configuration |
 | `index.html` | Would shadow `index.php` on the destination |
-| `wp-config.php` | Regenerated on the destination; also carries source DB credentials |
 | `wp-content/.htaccess` | Same as the docroot `.htaccess` |
 | `wp-content/cache`, `wp-content/et-cache`, `wp-content/upgrade` | Stale as soon as the domain changes |
 | `wp-content/object-cache-iwp.php` | Points at the source's cache backend |
@@ -134,6 +133,23 @@ passed in by the caller rather than hardcoded into `cli_archive_wordpress_files(
 
 **`vendor` is intentionally not on this list.** Composer dependencies are runtime code;
 removing them breaks any plugin that ships one.
+
+### wp-config.php must stay in the archive
+
+`process_migration_settings()` excludes `wp-config.php`, but only for the pull/staging
+flow — that destination writes its own. Local push must **not** copy that exclusion.
+
+`v-instawp-wordpress-restore` clears the docroot (`rm -rf wp-*`) before extracting, then
+reads the extracted `wp-config.php` to patch `DB_NAME` / `DB_USER` / `DB_PASSWORD` into
+it. It never creates one. Omitting it from the archive leaves the site with no config and
+no database, and the restore fails with:
+
+```
+ls: cannot access 'wp-config.php': No such file or directory
+```
+
+The source credentials the file carries are overwritten by that same step, so shipping it
+costs nothing.
 
 WordPress core (`wp-admin`, `wp-includes`) **is** included in the archive.
 

--- a/doc/migrations/local-push.md
+++ b/doc/migrations/local-push.md
@@ -17,14 +17,54 @@ content. Everything is derived from the plugin's own defaults.
 
 ## Workflow
 
-1. `cli_archive_wordpress_files()` builds a zip of the docroot
-2. `cli_archive_wordpress_db()` exports the database via `wp db export`
-3. `create_insta_site()` provisions a blank destination site
-4. A `migrates-v3/local-push` record is created for tracking
-5. `cli_upload_using_sftp()` uploads the zip and the SQL dump to the destination
-6. `cli_restore_website()` calls the `restore-raw` API and polls until it completes
-7. Both artifacts are deleted from the destination and from the local temp directory
-8. `migrates-v3/finish-local-staging` finalises the destination configuration
+1. `cli_local_push_preflight()` verifies the environment can complete the run
+2. `cli_archive_wordpress_files()` builds a zip of the docroot
+3. `cli_archive_wordpress_db()` exports the database via `wp db export`
+4. `create_insta_site()` provisions a blank destination site
+5. A `migrates-v3/local-push` record is created for tracking, carrying the site sizes
+6. `cli_upload_using_sftp()` uploads the zip and the SQL dump to the destination
+7. `cli_restore_website()` calls the `restore-raw` API and polls until it completes
+8. Both artifacts are deleted from the destination and from the local temp directory
+9. `migrates-v3/finish-local-staging` finalises the destination configuration
+
+## Preflight
+
+`cli_local_push_preflight()` runs before any work and fails with a single message
+naming everything that is missing:
+
+- `ZipArchive` or `PharData` must be available
+- the PHP temp directory must exist and be writable
+- at least `InstaWP_Tools::CLI_MIN_FREE_DISK_BYTES` must be free there
+
+The checks are **capability-based, not platform-based** — the command is not
+restricted to any operating system. The failure that was historically read as "this
+only works on macOS" was `wp db export` needing `mysqldump` on the `PATH`;
+`cli_archive_wordpress_db()` now returns a `WP_Error` carrying the underlying stderr
+instead of letting an unrelated error surface.
+
+## Progress reporting
+
+The tracking record is updated as the run proceeds. Local push previously wrote only
+`migration-finished`, so a migration appeared never to have started and the dashboard
+showed no size at all.
+
+| Point in the flow | Stage recorded |
+|---|---|
+| before upload | `push-initiated` |
+| around the files transfer | `push-files-in-progress`, `push-files-finished` |
+| around the database transfer | `push-db-in-progress`, `push-db-finished` |
+| after the restore completes | `push-finished` |
+| at the end | `migration-finished` |
+| any failure | `failed` |
+
+`file_size` and `db_size` are sent when the migration record is **created**, not via
+`update-status` — the same point and the same `get_total_sizes()` helpers the standard
+push flow uses, so the dashboard reads consistently across migration modes.
+
+Stage updates go through `InstaWP_Tools::cli_update_stage()`, which requires both the
+migration id and key. `instawp_update_migration_stages()` falls back to the stored
+`migrate_id` option when passed an empty one, which under WP-CLI could attribute a
+stage to an unrelated migration left over from the admin UI.
 
 ## Artifact cleanup
 

--- a/doc/two-way-sync.md
+++ b/doc/two-way-sync.md
@@ -46,6 +46,30 @@ Activity logging captures all changes on connected sites. Events are recorded an
 | GET | `/instawp-connect/v1/sync/summary` | Event summary |
 | POST | `/instawp-connect/v1/sync/download-media` | Download media files |
 
+### `sync/download-media` authorization
+
+This endpoint streams raw attachment bytes to the paired site, so it is gated harder than the
+event endpoints. `InstaWP_Sync_Apis::validate_sync_api_request()` runs both as the route's
+`permission_callback` and again at the top of the callback, and denies the request unless:
+
+1. The request carries `Authorization: Bearer <hash>` or `X-IWP-AUTH: <hash>`, where
+   `<hash>` is `sha256( connect_id . '_' . connect_uuid )` of the site being called.
+   The caller builds these headers with `instawp_get_migration_headers()`.
+2. The site is connected — `instawp_api_options` holds both `connect_id` and `connect_uuid`.
+3. The token matches the locally derived hash (`hash_equals()`).
+
+The `instawp_is_event_syncing` toggle is deliberately **not** part of this check. The peer site
+requests media while it processes events, which can happen after the toggle was switched off on
+this side, so gating on it would break legitimate syncs.
+
+Every denial returns a `WP_Error` — never a `WP_REST_Response`. A permission callback that
+returns anything other than `true`, `false`, `null` or `WP_Error` is read as "authorized" by
+`WP_REST_Server`, which is how CVE-class issue 86d406d23 allowed unauthenticated media
+downloads when the auth header was omitted.
+
+The callback additionally requires the requested ID to be an `attachment` post and the resolved
+file to sit inside the uploads directory, and it only serves the extensions in its allowlist.
+
 ## Features
 
 - Event filtering by type (posts, users, plugins, etc.)

--- a/includes/class-instawp-cli.php
+++ b/includes/class-instawp-cli.php
@@ -25,8 +25,11 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 
 			global $wp_version;
 
-			// Files backup
-			if ( is_wp_error( $archive_path_file = InstaWP_Tools::cli_archive_wordpress_files() ) ) {
+			// Files backup. The exclusion list has to be passed here: it was previously
+			// computed further down (for the migration API payload only) and never reached
+			// the archiver, so host-specific files such as the source .htaccess were copied
+			// verbatim to the destination.
+			if ( is_wp_error( $archive_path_file = InstaWP_Tools::cli_archive_wordpress_files( 'zip', InstaWP_Tools::get_local_push_excluded_paths() ) ) ) {
 				die( esc_html( $archive_path_file->get_error_message() ) );
 			}
 			WP_CLI::success( 'Files backup created successfully.' );
@@ -41,6 +44,11 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 
 			// Create Site
 			if ( is_wp_error( $create_site_res = InstaWP_Tools::create_insta_site( true ) ) ) {
+
+				// Nothing has been uploaded yet, but the local archives are already on disk
+				// and can be several gigabytes, so they are not left behind.
+				InstaWP_Tools::cli_delete_local_archives( array( $archive_path_file, $archive_path_db ) );
+
 				die( esc_html( $create_site_res->get_error_message() ) );
 			}
 
@@ -71,6 +79,10 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 			$migrate_res_data    = Helper::get_args_option( 'data', $migrate_res, array() );
 
 			if ( ! $migrate_res_status ) {
+
+				// Still nothing uploaded at this point, so only the local copies need clearing.
+				InstaWP_Tools::cli_delete_local_archives( array( $archive_path_file, $archive_path_db ) );
+
 				die( esc_html( $migrate_res_message ) );
 			}
 
@@ -88,6 +100,9 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 				// Mark the migration failed
 				instawp_update_migration_stages( array( 'failed' => true ), $migrate_id, $migrate_key );
 
+				// An upload may have completed before the failure, so clear both ends.
+				InstaWP_Tools::cli_cleanup_migration_artifacts( $site_id, $archive_path_file, $archive_path_db );
+
 				die( esc_html( $file_upload_status->get_error_message() ) );
 			}
 
@@ -97,8 +112,14 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 				// Mark the migration failed
 				instawp_update_migration_stages( array( 'failed' => true ), $migrate_id, $migrate_key );
 
+				InstaWP_Tools::cli_cleanup_migration_artifacts( $site_id, $archive_path_file, $archive_path_db );
+
 				die( esc_html( $file_upload_status->get_error_message() ) );
 			}
+
+			// The restore has consumed the uploaded copies, so clear them from the docroot
+			// and from the local temp directory before finishing up.
+			InstaWP_Tools::cli_cleanup_migration_artifacts( $site_id, $archive_path_file, $archive_path_db );
 
 			// Mark the migration failed
 			instawp_update_migration_stages( array( 'migration-finished' => true ), $migrate_id, $migrate_key );

--- a/includes/class-instawp-cli.php
+++ b/includes/class-instawp-cli.php
@@ -100,8 +100,21 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 				// Mark the migration failed
 				instawp_update_migration_stages( array( 'failed' => true ), $migrate_id, $migrate_key );
 
-				// An upload may have completed before the failure, so clear both ends.
-				InstaWP_Tools::cli_cleanup_migration_artifacts( $site_id, $archive_path_file, $archive_path_db );
+				// When the failure was in setting up the connection itself, nothing was
+				// uploaded and retrying it would only fail again — with a cleanup warning
+				// that obscures the real error. Anything later means a file may already have
+				// landed on the destination, so both ends are cleared.
+				$connection_failed = in_array(
+					$file_upload_status->get_error_code(),
+					array( 'sftp_enable_failed', 'sftp_login_failed' ),
+					true
+				);
+
+				if ( $connection_failed ) {
+					InstaWP_Tools::cli_delete_local_archives( array( $archive_path_file, $archive_path_db ) );
+				} else {
+					InstaWP_Tools::cli_cleanup_migration_artifacts( $site_id, $archive_path_file, $archive_path_db );
+				}
 
 				die( esc_html( $file_upload_status->get_error_message() ) );
 			}

--- a/includes/class-instawp-cli.php
+++ b/includes/class-instawp-cli.php
@@ -36,7 +36,7 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 			// computed further down (for the migration API payload only) and never reached
 			// the archiver, so host-specific files such as the source .htaccess were copied
 			// verbatim to the destination.
-			if ( is_wp_error( $archive_path_file = InstaWP_Tools::cli_archive_wordpress_files( 'zip', InstaWP_Tools::get_local_push_excluded_paths() ) ) ) {
+			if ( is_wp_error( $archive_path_file = InstaWP_Tools::cli_archive_wordpress_files( 'zip', InstaWP_Tools::get_local_push_excluded_paths(), InstaWP_Tools::get_local_push_excluded_dir_names() ) ) ) {
 				die( esc_html( $archive_path_file->get_error_message() ) );
 			}
 			WP_CLI::success( 'Files backup created successfully.' );

--- a/includes/class-instawp-cli.php
+++ b/includes/class-instawp-cli.php
@@ -25,13 +25,6 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 
 			global $wp_version;
 
-			// Checked before any work starts, so a missing compression extension, an
-			// unwritable temp directory or a full disk is reported as one clear message
-			// instead of surfacing later as a raw error from whichever step needed it.
-			if ( is_wp_error( $preflight = InstaWP_Tools::cli_local_push_preflight() ) ) {
-				WP_CLI::error( $preflight->get_error_message() );
-			}
-
 			// Files backup. The exclusion list has to be passed here: it was previously
 			// computed further down (for the migration API payload only) and never reached
 			// the archiver, so host-specific files such as the source .htaccess were copied

--- a/includes/class-instawp-cli.php
+++ b/includes/class-instawp-cli.php
@@ -25,6 +25,13 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 
 			global $wp_version;
 
+			// Checked before any work starts, so a missing compression extension, an
+			// unwritable temp directory or a full disk is reported as one clear message
+			// instead of surfacing later as a raw error from whichever step needed it.
+			if ( is_wp_error( $preflight = InstaWP_Tools::cli_local_push_preflight() ) ) {
+				WP_CLI::error( $preflight->get_error_message() );
+			}
+
 			// Files backup. The exclusion list has to be passed here: it was previously
 			// computed further down (for the migration API payload only) and never reached
 			// the archiver, so host-specific files such as the source .htaccess were copied
@@ -38,9 +45,19 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 
 			// Database backup
 			$archive_path_db = InstaWP_Tools::cli_archive_wordpress_db();
-			WP_CLI::success( 'Database backup created successfully.' );
 
 			delete_option( 'instawp_parent_is_on_local' );
+
+			// The export shells out to mysqldump, so this is where an unreachable database
+			// or a missing mysqldump is caught. The files archive already exists at this
+			// point and would otherwise be orphaned in the temp directory.
+			if ( is_wp_error( $archive_path_db ) ) {
+				InstaWP_Tools::cli_delete_local_archives( array( $archive_path_file ) );
+
+				WP_CLI::error( $archive_path_db->get_error_message() );
+			}
+
+			WP_CLI::success( 'Database backup created successfully.' );
 
 			// Create Site
 			if ( is_wp_error( $create_site_res = InstaWP_Tools::create_insta_site( true ) ) ) {
@@ -71,6 +88,12 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 				'php_version'       => PHP_VERSION,
 				'wp_version'        => $wp_version,
 				'plugin_version'    => INSTAWP_PLUGIN_VERSION,
+				// Sizes are recorded when the migration is created, which is why they were
+				// left at zero for local push: the standard flow sends them here and this one
+				// did not. The same helpers are used so the dashboard reads consistently
+				// across migration modes.
+				'file_size'         => InstaWP_Tools::get_total_sizes( 'files', $migrate_settings ),
+				'db_size'           => InstaWP_Tools::get_total_sizes( 'db' ),
 				'migrate_key'       => $migrate_key,
 			);
 			$migrate_res         = Curl::do_curl( 'migrates-v3/local-push', $migrate_args );
@@ -94,8 +117,14 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 			// Wait 10 seconds
 			sleep( 10 );
 
-			// Upload files and db using SFTP
-			if ( is_wp_error( $file_upload_status = InstaWP_Tools::cli_upload_using_sftp( $site_id, $archive_path_file, $archive_path_db ) ) ) {
+			// Marks the transfer as under way. Local push previously recorded no stage at
+			// all between creating the migration and finishing it, so the dashboard showed
+			// a migration that never appeared to start.
+			instawp_update_migration_stages( array( 'push-initiated' => true ), $migrate_id, $migrate_key );
+
+			// Upload files and db using SFTP. The migration identifiers are passed so the
+			// per-artifact stages are recorded as each transfer starts and completes.
+			if ( is_wp_error( $file_upload_status = InstaWP_Tools::cli_upload_using_sftp( $site_id, $archive_path_file, $archive_path_db, $migrate_id, $migrate_key ) ) ) {
 
 				// Mark the migration failed
 				instawp_update_migration_stages( array( 'failed' => true ), $migrate_id, $migrate_key );
@@ -130,11 +159,14 @@ if ( ! class_exists( 'INSTAWP_CLI_Commands' ) ) {
 				die( esc_html( $file_upload_status->get_error_message() ) );
 			}
 
+			// The transfer and the restore are both done at this point.
+			instawp_update_migration_stages( array( 'push-finished' => true ), $migrate_id, $migrate_key );
+
 			// The restore has consumed the uploaded copies, so clear them from the docroot
 			// and from the local temp directory before finishing up.
 			InstaWP_Tools::cli_cleanup_migration_artifacts( $site_id, $archive_path_file, $archive_path_db );
 
-			// Mark the migration failed
+			// Mark the migration finished
 			instawp_update_migration_stages( array( 'migration-finished' => true ), $migrate_id, $migrate_key );
 
 			// Finish configuration of the staging website

--- a/includes/class-instawp-tools.php
+++ b/includes/class-instawp-tools.php
@@ -10,6 +10,15 @@ defined( 'ABSPATH' ) || exit;
 class InstaWP_Tools {
 
 	/**
+	 * Minimum free space required in the temp directory before a local push starts.
+	 *
+	 * The files archive and the database dump are both written there before upload, so
+	 * running out of space mid-run wastes the whole transfer. 2 GB is a floor, not an
+	 * estimate of the site size — it only catches an already-full disk up front.
+	 */
+	const CLI_MIN_FREE_DISK_BYTES = 2147483648;
+
+	/**
 	 * Verify an AJAX request: validates nonce and user capability.
 	 * Sends a JSON error response and exits if either check fails.
 	 *
@@ -2116,13 +2125,97 @@ include $file_path;';
 		return apply_filters( 'instawp/filters/localize_data', $localize_data );
 	}
 
+	/**
+	 * Requirements that have to hold before a local push is attempted.
+	 *
+	 * Checked up front so a missing dependency is reported as one clear message rather
+	 * than surfacing later as a raw error from whichever component happened to need it.
+	 *
+	 * Deliberately capability-based rather than platform-based: the command is not
+	 * restricted to any operating system, it just needs a compression extension, a
+	 * writable temp directory and a working database export.
+	 *
+	 * @return true|WP_Error
+	 */
+	public static function cli_local_push_preflight() {
+
+		$errors = array();
+
+		if ( ! class_exists( 'ZipArchive' ) && ! class_exists( 'PharData' ) ) {
+			$errors[] = esc_html__( 'Neither the ZipArchive nor the PharData PHP extension is available; one is required to build the backup.', 'instawp-connect' );
+		}
+
+		$temp_dir = get_temp_dir();
+
+		if ( empty( $temp_dir ) || ! is_dir( $temp_dir ) ) {
+			$errors[] = esc_html__( 'The PHP temporary directory could not be located.', 'instawp-connect' );
+		} elseif ( ! is_writable( $temp_dir ) ) {
+			/* translators: %s: temporary directory path. */
+			$errors[] = sprintf( esc_html__( 'The temporary directory is not writable: %s', 'instawp-connect' ), $temp_dir );
+		} else {
+			// The archive and the database dump are both written here before upload, so a
+			// full disk fails the migration halfway through rather than up front.
+			$free_space = @disk_free_space( $temp_dir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+
+			if ( false !== $free_space && $free_space < self::CLI_MIN_FREE_DISK_BYTES ) {
+				$errors[] = sprintf(
+					/* translators: 1: temporary directory path, 2: human readable free space. */
+					esc_html__( 'Not enough free space in the temporary directory %1$s (%2$s available). The backup is written there before it is uploaded.', 'instawp-connect' ),
+					$temp_dir,
+					size_format( $free_space )
+				);
+			}
+		}
+
+		if ( ! empty( $errors ) ) {
+			return new WP_Error( 'local_push_preflight_failed', implode( ' ', $errors ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Export the database to a file in the temp directory.
+	 *
+	 * @return string|WP_Error Path to the dump, or WP_Error when the export failed.
+	 */
 	public static function cli_archive_wordpress_db() {
 
 		$archive_dir  = get_temp_dir();
 		$archive_name = 'wordpress_db_backup_' . date( 'Y-m-d_H-i-s' );
 		$db_file_name = $archive_dir . $archive_name . '.sql';
 
-		WP_CLI::runcommand( 'db export ' . $db_file_name );
+		// exit_error => false so a failing export is reported here with its own stderr
+		// instead of halting WP-CLI with a bare message from the underlying tool. The
+		// export shells out to mysqldump, so this is where a missing or unreachable
+		// mysqldump surfaces.
+		$export = WP_CLI::runcommand(
+			'db export ' . escapeshellarg( $db_file_name ),
+			array(
+				'exit_error' => false,
+				'return'     => 'all',
+			)
+		);
+
+		$return_code = is_object( $export ) && isset( $export->return_code ) ? (int) $export->return_code : 0;
+
+		if ( 0 !== $return_code ) {
+			$stderr = is_object( $export ) && ! empty( $export->stderr ) ? trim( $export->stderr ) : '';
+
+			return new WP_Error(
+				'db_export_failed',
+				sprintf(
+					/* translators: %s: error output from the database export. */
+					esc_html__( 'Database export failed. %s', 'instawp-connect' ),
+					'' !== $stderr ? $stderr : esc_html__( 'Check that the database is reachable and that mysqldump is installed and on the PATH.', 'instawp-connect' )
+				)
+			);
+		}
+
+		// A zero exit code with no usable file still means there is nothing to upload.
+		if ( ! file_exists( $db_file_name ) || 0 === filesize( $db_file_name ) ) {
+			return new WP_Error( 'db_export_failed', esc_html__( 'The database export produced an empty file.', 'instawp-connect' ) );
+		}
 
 		return $db_file_name;
 	}
@@ -2683,7 +2776,41 @@ include $file_path;';
 		self::cli_delete_local_archives( array( $file_path, $db_path ) );
 	}
 
-	public static function cli_upload_using_sftp( $site_id, $file_path, $db_path ) {
+	/**
+	 * Record a migration stage transition.
+	 *
+	 * Wrapped so the identifiers are checked first: instawp_update_migration_stages()
+	 * falls back to the stored migrate_id option when passed an empty one, which for a
+	 * CLI run could attribute the stage to an unrelated migration left over from the
+	 * admin UI.
+	 *
+	 * @param array  $stages      Stage keys to set.
+	 * @param string $migrate_id  Migration id.
+	 * @param string $migrate_key Migration key.
+	 *
+	 * @return void
+	 */
+	protected static function cli_update_stage( $stages, $migrate_id, $migrate_key ) {
+
+		if ( empty( $migrate_id ) || empty( $migrate_key ) ) {
+			return;
+		}
+
+		instawp_update_migration_stages( $stages, $migrate_id, $migrate_key );
+	}
+
+	/**
+	 * Upload the files archive and the database dump to the destination over SFTP.
+	 *
+	 * @param int    $site_id     Destination site id.
+	 * @param string $file_path   Local path of the files archive.
+	 * @param string $db_path     Local path of the database dump.
+	 * @param string $migrate_id  Migration id, for stage reporting. Optional.
+	 * @param string $migrate_key Migration key, for stage reporting. Optional.
+	 *
+	 * @return true|WP_Error
+	 */
+	public static function cli_upload_using_sftp( $site_id, $file_path, $db_path, $migrate_id = '', $migrate_key = '' ) {
 
 		$connection = self::cli_get_sftp_connection( $site_id );
 
@@ -2694,19 +2821,29 @@ include $file_path;';
 		$sftp      = $connection['sftp'];
 		$sftp_host = $connection['host'];
 
+		// Stages are reported around each transfer rather than around the method as a
+		// whole, so the dashboard reflects which artifact is actually moving.
+		self::cli_update_stage( array( 'push-files-in-progress' => true ), $migrate_id, $migrate_key );
+
 		$sftp_file_upload_status = $sftp->put( "web/$sftp_host/public_html/" . basename( $file_path ), $file_path, SFTP::SOURCE_LOCAL_FILE );
 
 		if ( ! $sftp_file_upload_status ) {
 			return new WP_Error( 'sftp_file_upload_failed', esc_html__( 'SFTP upload failed for files.', 'instawp-connect' ) );
 		}
 
+		self::cli_update_stage( array( 'push-files-finished' => true ), $migrate_id, $migrate_key );
+
 		WP_CLI::success( 'File uploaded successfully using SFTP.' );
+
+		self::cli_update_stage( array( 'push-db-in-progress' => true ), $migrate_id, $migrate_key );
 
 		$sftp_db_upload_status = $sftp->put( "web/$sftp_host/public_html/" . basename( $db_path ), $db_path, SFTP::SOURCE_LOCAL_FILE );
 
 		if ( ! $sftp_db_upload_status ) {
 			return new WP_Error( 'sftp_db_upload_failed', esc_html__( 'SFTP upload failed for database.', 'instawp-connect' ) );
 		}
+
+		self::cli_update_stage( array( 'push-db-finished' => true ), $migrate_id, $migrate_key );
 
 		WP_CLI::success( 'Database uploaded successfully using SFTP.' );
 

--- a/includes/class-instawp-tools.php
+++ b/includes/class-instawp-tools.php
@@ -2127,6 +2127,53 @@ include $file_path;';
 		return $db_file_name;
 	}
 
+	/**
+	 * Paths that must never be copied into a local-push archive.
+	 *
+	 * This deliberately does NOT reuse migrate_settings['excluded_paths']. That list
+	 * is inventory-aware: process_migration_settings() also excludes plugins and themes
+	 * whose checksum matches the official wp.org build, on the understanding that the
+	 * destination re-downloads them from inventory_items. The local-push flow ships the
+	 * archive straight to the restore-raw API, which has no inventory reconstruction
+	 * step, so honouring that list would silently drop working plugins from the
+	 * migrated site.
+	 *
+	 * Only host-specific files, caches and logs are listed here. WordPress core
+	 * (wp-admin / wp-includes) is intentionally left in the archive.
+	 *
+	 * @return array Relative, forward-slash separated paths to skip.
+	 */
+	public static function get_local_push_excluded_paths() {
+
+		// Mirrors the wp-content folder name resolution used by process_migration_settings().
+		$relative_dir = str_replace( ABSPATH, '', WP_CONTENT_DIR );
+		$relative_dir = basename( $relative_dir );
+
+		$mu_plugins_dir = $relative_dir . DIRECTORY_SEPARATOR . 'mu-plugins';
+
+		return array(
+			// Host-specific server config. The source .htaccess carries the origin host's
+			// PHP handlers and canonical-redirect rules, which break the site on our stack.
+			'.htaccess',
+			'.user.ini',
+			'index.html',
+			// Regenerated on the destination; copying it would also carry the source DB credentials.
+			'wp-config.php',
+			$relative_dir . DIRECTORY_SEPARATOR . '.htaccess',
+			// Caches are stale the moment the site changes domain.
+			$relative_dir . DIRECTORY_SEPARATOR . 'cache',
+			$relative_dir . DIRECTORY_SEPARATOR . 'et-cache',
+			$relative_dir . DIRECTORY_SEPARATOR . 'upgrade',
+			$relative_dir . DIRECTORY_SEPARATOR . 'object-cache-iwp.php',
+			$mu_plugins_dir . DIRECTORY_SEPARATOR . 'mu-pluginsold',
+			$mu_plugins_dir . DIRECTORY_SEPARATOR . 'redis-cache-pro.php',
+			$mu_plugins_dir . DIRECTORY_SEPARATOR . 'sso.php',
+			$mu_plugins_dir . DIRECTORY_SEPARATOR . 'wp-stack-cache.php',
+			// The destination runs its own copy of the connect plugin.
+			$relative_dir . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR . 'instawp-connect',
+		);
+	}
+
 	public static function cli_archive_wordpress_files( $type = 'zip', $dirs_to_skip = array() ) {
 
 		$archive_dir         = get_temp_dir();
@@ -2160,22 +2207,54 @@ include $file_path;';
 				return new WP_Error( 'zip_is_not_opening', esc_html__( 'Zip archive is not opening.', 'instawp-connect' ) );
 			}
 
-			$skip_folders     = array(
-				'wp-content' . DIRECTORY_SEPARATOR . 'instawpbackups',
-				'wp-content' . DIRECTORY_SEPARATOR . 'upgrade',
-				'wp-content' . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR . 'instawp-connect',
-				'wp-content' . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR . 'instawp-helper',
-				'wp-content' . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR . 'iwp-migration',
+			/**
+			 * Normalise a path for comparison: forward slashes, no leading or trailing
+			 * separator. Callers pass exclusion lists that mix DIRECTORY_SEPARATOR with
+			 * literal '/' and sometimes carry a trailing slash, so both sides of every
+			 * comparison below are run through this first.
+			 */
+			$normalize_path = function ( $path ) {
+				return trim( str_replace( '\\', '/', (string) $path ), '/' );
+			};
+
+			// $directories_to_skip carries the caller-supplied $dirs_to_skip. It was
+			// previously built but only ever used by the tgz branch above, which meant the
+			// zip branch — the default — silently ignored every requested exclusion.
+			$skip_folders = array_map(
+				$normalize_path,
+				array_merge(
+					array(
+						'wp-content' . DIRECTORY_SEPARATOR . 'instawpbackups',
+						'wp-content' . DIRECTORY_SEPARATOR . 'upgrade',
+						'wp-content' . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR . 'instawp-connect',
+						'wp-content' . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR . 'instawp-helper',
+						'wp-content' . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR . 'iwp-migration',
+					),
+					$directories_to_skip
+				)
 			);
-			$filter_directory = function ( SplFileInfo $file, $key, RecursiveDirectoryIterator $iterator ) use ( $skip_folders ) {
+			$skip_folders = array_values( array_unique( array_filter( $skip_folders, 'strlen' ) ) );
 
-				$relative_path = ! empty( $iterator->getSubPath() ) ? $iterator->getSubPath() . DIRECTORY_SEPARATOR . $file->getBasename() : $file->getBasename();
+			// Log files are matched by basename at any depth rather than by path: cPanel
+			// and similar hosts drop an error_log into every directory that throws, and
+			// they are never useful on the destination (they also leak the source's
+			// absolute filesystem paths).
+			$skip_basenames = array( 'error_log', 'debug.log' );
 
-				if ( in_array( $relative_path, $skip_folders ) ) {
+			$filter_directory = function ( SplFileInfo $file, $key, RecursiveDirectoryIterator $iterator ) use ( $skip_folders, $skip_basenames, $normalize_path ) {
+
+				$sub_path      = $normalize_path( $iterator->getSubPath() );
+				$relative_path = '' !== $sub_path ? $sub_path . '/' . $file->getBasename() : $file->getBasename();
+
+				if ( ! $file->isDir() && in_array( $file->getBasename(), $skip_basenames, true ) ) {
 					return false;
 				}
 
-				return ! in_array( $iterator->getSubPath(), $skip_folders );
+				if ( in_array( $relative_path, $skip_folders, true ) ) {
+					return false;
+				}
+
+				return ! in_array( $sub_path, $skip_folders, true );
 			};
 			$directory        = new RecursiveDirectoryIterator( ABSPATH, RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::FOLLOW_SYMLINKS );
 			$iterator         = new RecursiveIteratorIterator( new RecursiveCallbackFilterIterator( $directory, $filter_directory ), RecursiveIteratorIterator::LEAVES_ONLY, RecursiveIteratorIterator::CATCH_GET_CHILD );
@@ -2183,13 +2262,26 @@ include $file_path;';
 			try {
 				$limitedIterator = new LimitIterator( $iterator );
 			} catch ( Exception $e ) {
+
+				// The archive handle is already open at this point, so bail out cleanly
+				// rather than leaving a partial zip behind in the temp directory.
+				$zip->close();
+				self::cli_delete_local_archives( array( $archive_path ) );
+
 				return new WP_Error( 'limited_worker_is_not_working', $e->getMessage() );
 			}
+
+			// WordPress defines ABSPATH as __DIR__ . '/', so on Windows it mixes separators
+			// ("C:\site/"). The file path is converted to forward slashes below, so ABSPATH
+			// has to be converted too — otherwise it never matches, the docroot prefix is
+			// left in place, and every entry is stored in the archive under its absolute
+			// path instead of relative to the site root.
+			$abspath_prefix = str_replace( '\\', '/', ABSPATH );
 
 			foreach ( $limitedIterator as $file ) {
 				if ( ! $file->isDir() ) {
 					$filePath     = $file->getRealPath();
-					$relativePath = str_replace( ABSPATH, '', str_replace( '\\', '/', $filePath ) );
+					$relativePath = str_replace( $abspath_prefix, '', str_replace( '\\', '/', $filePath ) );
 
 					if ( ! is_readable( $filePath ) ) {
 						error_log( 'Can not read file: ' . $filePath );
@@ -2269,7 +2361,20 @@ include $file_path;';
 		return (array) $sites_res_data;
 	}
 
-	public static function cli_upload_using_sftp( $site_id, $file_path, $db_path ) {
+	/**
+	 * Open an SFTP connection to a destination site.
+	 *
+	 * Extracted from cli_upload_using_sftp() so the post-restore cleanup can reuse it.
+	 * The cleanup deliberately opens a fresh connection rather than holding on to the
+	 * upload's: the restore poll that runs in between can take a long time, by which
+	 * point the original session has usually expired.
+	 *
+	 * @param int  $site_id Destination site id.
+	 * @param bool $verbose Whether to emit the per-step WP-CLI success messages.
+	 *
+	 * @return array|WP_Error array( 'sftp' => SFTP, 'host' => string ) on success.
+	 */
+	public static function cli_get_sftp_connection( $site_id, $verbose = true ) {
 		$connect_id = instawp_get_connect_id();
 
 		// Enabling SFTP
@@ -2279,7 +2384,9 @@ include $file_path;';
 			return new WP_Error( 'sftp_enable_failed', Helper::get_args_option( 'message', $sftp_enable_res ) );
 		}
 
-		WP_CLI::success( 'SFTP enabled for the website.' );
+		if ( $verbose ) {
+			WP_CLI::success( 'SFTP enabled for the website.' );
+		}
 
 		// Getting SFTP details of $site_id
 		$sftp_details_res = Curl::do_curl( "connects/{$connect_id}/sites/{$site_id}/sftp-details", array(), array(), 'GET' );
@@ -2288,7 +2395,9 @@ include $file_path;';
 			return new WP_Error( 'sftp_enable_failed', Helper::get_args_option( 'message', $sftp_details_res ) );
 		}
 
-		WP_CLI::success( 'SFTP details fetched successfully.' );
+		if ( $verbose ) {
+			WP_CLI::success( 'SFTP details fetched successfully.' );
+		}
 
 		$sftp_details_res_data = Helper::get_args_option( 'data', $sftp_details_res, array() );
 		$sftp_host             = Helper::get_args_option( 'host', $sftp_details_res_data );
@@ -2307,7 +2416,243 @@ include $file_path;';
 			return new WP_Error( 'sftp_login_failed', $e->getMessage() );
 		}
 
-		WP_CLI::success( 'SFTP login successful to the server.' );
+		if ( $verbose ) {
+			WP_CLI::success( 'SFTP login successful to the server.' );
+		}
+
+		return array(
+			'sftp' => $sftp,
+			'host' => $sftp_host,
+		);
+	}
+
+	/**
+	 * Remote path of a migration artifact inside the destination docroot.
+	 *
+	 * @param string $sftp_host Destination SFTP host.
+	 * @param string $path      Local path of the artifact.
+	 *
+	 * @return string
+	 */
+	protected static function cli_remote_artifact_path( $sftp_host, $path ) {
+		return "web/$sftp_host/public_html/" . basename( $path );
+	}
+
+	/**
+	 * Whether a path refers to a migration archive created by this class.
+	 *
+	 * Shared by the local and the remote cleanup so neither can be turned into an
+	 * arbitrary delete. The check is on the file name alone, because the remote copy is
+	 * addressed by basename inside the destination docroot and there is nothing else
+	 * about it to verify from here.
+	 *
+	 * @param string $path Local or remote file path.
+	 *
+	 * @return bool
+	 */
+	protected static function is_migration_artifact( $path ) {
+
+		// Separators are normalised first: basename() does not treat a backslash as a
+		// separator on non-Windows systems, and these paths can originate on Windows.
+		$basename = basename( str_replace( '\\', '/', (string) $path ) );
+
+		if ( '' === $basename ) {
+			return false;
+		}
+
+		// Extensions produced by cli_archive_wordpress_files() and cli_archive_wordpress_db(),
+		// including the intermediate .tar / .tar.gz files written by the Phar branch.
+		$allowed_extensions = array( 'zip', 'tgz', 'sql', 'tar', 'gz' );
+
+		if ( ! in_array( strtolower( pathinfo( $basename, PATHINFO_EXTENSION ) ), $allowed_extensions, true ) ) {
+			return false;
+		}
+
+		// Names generated by those same two methods.
+		return 0 === strpos( $basename, 'wordpress_backup_' ) || 0 === strpos( $basename, 'wordpress_db_backup_' );
+	}
+
+	/**
+	 * Delete the uploaded migration artifacts from the destination docroot.
+	 *
+	 * The archive and database dump have to be uploaded into public_html because the
+	 * restore API resolves them by basename relative to the docroot. Nothing in the
+	 * restore removes them afterwards, which leaves a complete copy of the site and its
+	 * database publicly downloadable — the web server serves .zip and .sql statically,
+	 * so a rewrite-based guard would not cover them either. They must be deleted.
+	 *
+	 * @param int    $site_id   Destination site id.
+	 * @param string $file_path Local path of the uploaded files archive.
+	 * @param string $db_path   Local path of the uploaded database dump.
+	 *
+	 * @return true|WP_Error
+	 */
+	public static function cli_delete_remote_artifacts( $site_id, $file_path, $db_path ) {
+
+		$connection = self::cli_get_sftp_connection( $site_id, false );
+
+		if ( is_wp_error( $connection ) ) {
+			return $connection;
+		}
+
+		$sftp      = $connection['sftp'];
+		$sftp_host = $connection['host'];
+		$failed    = array();
+
+		foreach ( array( $file_path, $db_path ) as $path ) {
+
+			if ( empty( $path ) ) {
+				continue;
+			}
+
+			// Only ever remove archives this class created. The remote name is derived from
+			// the local archive path, so without this a caller passing anything else — a
+			// site file, a path with traversal segments — would turn this into an arbitrary
+			// delete inside a live destination docroot.
+			if ( ! self::is_migration_artifact( $path ) ) {
+				self::cli_warn( sprintf( 'Skipped remote cleanup of an unexpected file: %s', basename( $path ) ) );
+				continue;
+			}
+
+			$remote_path = self::cli_remote_artifact_path( $sftp_host, $path );
+
+			// basename() above already strips traversal segments; this rejects a docroot
+			// prefix built from an unexpected SFTP host rather than trusting it blindly.
+			if ( false !== strpos( $remote_path, '..' ) ) {
+				self::cli_warn( sprintf( 'Skipped remote cleanup of an unsafe path: %s', $remote_path ) );
+				continue;
+			}
+
+			// An artifact that never made it to the server is not a cleanup failure.
+			if ( ! $sftp->file_exists( $remote_path ) ) {
+				continue;
+			}
+
+			if ( ! $sftp->delete( $remote_path, false ) ) {
+				$failed[] = $remote_path;
+			}
+		}
+
+		if ( ! empty( $failed ) ) {
+			return new WP_Error(
+				'artifact_cleanup_failed',
+				sprintf(
+					/* translators: %s: comma separated list of remote file paths. */
+					esc_html__( 'Could not remove migration artifacts from the destination: %s', 'instawp-connect' ),
+					implode( ', ', $failed )
+				)
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Delete the migration archives written to the local temp directory.
+	 *
+	 * Every path is validated before removal: it must resolve to a regular file inside
+	 * the temp directory and carry one of the extensions this class creates. This runs
+	 * on failure paths, where the caller's state may not be what it expects, so anything
+	 * that does not look like an archive we produced is reported and left untouched
+	 * rather than deleted. Paths are resolved with realpath() first, so a symlink is
+	 * judged by its target and cannot be used to reach outside the temp directory.
+	 *
+	 * @param array $paths Local file paths.
+	 *
+	 * @return void
+	 */
+	public static function cli_delete_local_archives( $paths = array() ) {
+
+		// Resolved once. Separators are normalised because get_temp_dir() and realpath()
+		// can return different forms on Windows, and realpath() also resolves the symlink
+		// behind /tmp on macOS — both sides of the comparison have to agree.
+		$temp_dir = realpath( get_temp_dir() );
+		$temp_dir = ! empty( $temp_dir ) ? trailingslashit( str_replace( '\\', '/', $temp_dir ) ) : '';
+
+		foreach ( (array) $paths as $path ) {
+
+			if ( empty( $path ) || ! is_string( $path ) ) {
+				continue;
+			}
+
+			$real_path = realpath( $path );
+
+			// Already gone, or never created — nothing to clean up.
+			if ( empty( $real_path ) || ! is_file( $real_path ) ) {
+				continue;
+			}
+
+			$normalized = str_replace( '\\', '/', $real_path );
+
+			if ( empty( $temp_dir ) || 0 !== strpos( $normalized, $temp_dir ) ) {
+				self::cli_warn( sprintf( 'Skipped cleanup of a file outside the temporary directory: %s', $real_path ) );
+				continue;
+			}
+
+			if ( ! self::is_migration_artifact( $normalized ) ) {
+				self::cli_warn( sprintf( 'Skipped cleanup of an unexpected file: %s', $real_path ) );
+				continue;
+			}
+
+			wp_delete_file( $real_path );
+		}
+	}
+
+	/**
+	 * Emit a WP-CLI warning when running under WP-CLI.
+	 *
+	 * The cleanup helpers are also reachable from cli_archive_wordpress_files(), which is
+	 * not guaranteed to run in a WP-CLI context, so the class is checked before use.
+	 *
+	 * @param string $message Warning message.
+	 *
+	 * @return void
+	 */
+	protected static function cli_warn( $message ) {
+
+		if ( class_exists( 'WP_CLI' ) ) {
+			WP_CLI::warning( $message );
+		}
+	}
+
+	/**
+	 * Remove the migration artifacts from the destination and the local machine.
+	 *
+	 * Called on every exit path of the local push command, including the failure paths
+	 * where an upload may already have completed before the error, so that a copy of the
+	 * site and its database is never left behind in the destination docroot.
+	 *
+	 * @param int    $site_id   Destination site id.
+	 * @param string $file_path Local path of the files archive.
+	 * @param string $db_path   Local path of the database dump.
+	 *
+	 * @return void
+	 */
+	public static function cli_cleanup_migration_artifacts( $site_id, $file_path, $db_path ) {
+
+		$remote_cleanup = self::cli_delete_remote_artifacts( $site_id, $file_path, $db_path );
+
+		if ( is_wp_error( $remote_cleanup ) ) {
+			// Surfaced rather than swallowed: a leftover artifact is a data exposure, so the
+			// operator needs the path in order to remove it by hand.
+			WP_CLI::warning( $remote_cleanup->get_error_message() );
+		} else {
+			WP_CLI::success( 'Migration files removed from the destination server.' );
+		}
+
+		self::cli_delete_local_archives( array( $file_path, $db_path ) );
+	}
+
+	public static function cli_upload_using_sftp( $site_id, $file_path, $db_path ) {
+
+		$connection = self::cli_get_sftp_connection( $site_id );
+
+		if ( is_wp_error( $connection ) ) {
+			return $connection;
+		}
+
+		$sftp      = $connection['sftp'];
+		$sftp_host = $connection['host'];
 
 		$sftp_file_upload_status = $sftp->put( "web/$sftp_host/public_html/" . basename( $file_path ), $file_path, SFTP::SOURCE_LOCAL_FILE );
 

--- a/includes/class-instawp-tools.php
+++ b/includes/class-instawp-tools.php
@@ -2280,8 +2280,14 @@ include $file_path;';
 
 			foreach ( $limitedIterator as $file ) {
 				if ( ! $file->isDir() ) {
-					$filePath     = $file->getRealPath();
-					$relativePath = str_replace( $abspath_prefix, '', str_replace( '\\', '/', $filePath ) );
+					$filePath       = $file->getRealPath();
+					$normalizedPath = str_replace( '\\', '/', $filePath );
+
+					// Stripped only where it is genuinely the prefix. A global replace would
+					// also rewrite a later occurrence of the same string inside the path.
+					$relativePath = 0 === strpos( $normalizedPath, $abspath_prefix )
+						? substr( $normalizedPath, strlen( $abspath_prefix ) )
+						: $normalizedPath;
 
 					if ( ! is_readable( $filePath ) ) {
 						error_log( 'Can not read file: ' . $filePath );
@@ -2485,7 +2491,7 @@ include $file_path;';
 	 * @param string $file_path Local path of the uploaded files archive.
 	 * @param string $db_path   Local path of the uploaded database dump.
 	 *
-	 * @return true|WP_Error
+	 * @return int|WP_Error Number of artifacts actually removed, or WP_Error on failure.
 	 */
 	public static function cli_delete_remote_artifacts( $site_id, $file_path, $db_path ) {
 
@@ -2498,6 +2504,7 @@ include $file_path;';
 		$sftp      = $connection['sftp'];
 		$sftp_host = $connection['host'];
 		$failed    = array();
+		$removed   = 0;
 
 		foreach ( array( $file_path, $db_path ) as $path ) {
 
@@ -2530,7 +2537,10 @@ include $file_path;';
 
 			if ( ! $sftp->delete( $remote_path, false ) ) {
 				$failed[] = $remote_path;
+				continue;
 			}
+
+			++$removed;
 		}
 
 		if ( ! empty( $failed ) ) {
@@ -2544,7 +2554,9 @@ include $file_path;';
 			);
 		}
 
-		return true;
+		// A count rather than a bare true, so the caller can tell "removed something" from
+		// "there was nothing to remove" and not report a cleanup that never happened.
+		return $removed;
 	}
 
 	/**
@@ -2616,6 +2628,20 @@ include $file_path;';
 	}
 
 	/**
+	 * Emit a WP-CLI success message when running under WP-CLI.
+	 *
+	 * @param string $message Message to display.
+	 *
+	 * @return void
+	 */
+	protected static function cli_success( $message ) {
+
+		if ( class_exists( 'WP_CLI' ) ) {
+			WP_CLI::success( $message );
+		}
+	}
+
+	/**
 	 * Remove the migration artifacts from the destination and the local machine.
 	 *
 	 * Called on every exit path of the local push command, including the failure paths
@@ -2635,9 +2661,23 @@ include $file_path;';
 		if ( is_wp_error( $remote_cleanup ) ) {
 			// Surfaced rather than swallowed: a leftover artifact is a data exposure, so the
 			// operator needs the path in order to remove it by hand.
-			WP_CLI::warning( $remote_cleanup->get_error_message() );
-		} else {
-			WP_CLI::success( 'Migration files removed from the destination server.' );
+			self::cli_warn( $remote_cleanup->get_error_message() );
+		} elseif ( $remote_cleanup > 0 ) {
+			// Only reported when something was actually deleted. Claiming a removal that did
+			// not happen — for instance when the upload failed before either file landed —
+			// would be the same false success this command is being fixed for.
+			self::cli_success(
+				sprintf(
+					/* translators: %d: number of files removed from the destination. */
+					_n(
+						'%d migration file removed from the destination server.',
+						'%d migration files removed from the destination server.',
+						$remote_cleanup,
+						'instawp-connect'
+					),
+					$remote_cleanup
+				)
+			);
 		}
 
 		self::cli_delete_local_archives( array( $file_path, $db_path ) );

--- a/includes/class-instawp-tools.php
+++ b/includes/class-instawp-tools.php
@@ -2234,6 +2234,14 @@ include $file_path;';
 	 * Only host-specific files, caches and logs are listed here. WordPress core
 	 * (wp-admin / wp-includes) is intentionally left in the archive.
 	 *
+	 * wp-config.php is deliberately NOT excluded. process_migration_settings() does
+	 * exclude it, but only for the pull/staging flow, whose destination writes its own.
+	 * The restore behind local push clears the docroot and then reads the extracted
+	 * wp-config.php to patch DB_NAME / DB_USER / DB_PASSWORD into it — it never creates
+	 * one. Leaving it out of the archive therefore produces a site with no wp-config and
+	 * no database, which reports as a failed restore. The source credentials it carries
+	 * are overwritten by that same step.
+	 *
 	 * @return array Relative, forward-slash separated paths to skip.
 	 */
 	public static function get_local_push_excluded_paths() {
@@ -2250,8 +2258,6 @@ include $file_path;';
 			'.htaccess',
 			'.user.ini',
 			'index.html',
-			// Regenerated on the destination; copying it would also carry the source DB credentials.
-			'wp-config.php',
 			$relative_dir . DIRECTORY_SEPARATOR . '.htaccess',
 			// Caches are stale the moment the site changes domain.
 			$relative_dir . DIRECTORY_SEPARATOR . 'cache',

--- a/includes/class-instawp-tools.php
+++ b/includes/class-instawp-tools.php
@@ -10,15 +10,6 @@ defined( 'ABSPATH' ) || exit;
 class InstaWP_Tools {
 
 	/**
-	 * Minimum free space required in the temp directory before a local push starts.
-	 *
-	 * The files archive and the database dump are both written there before upload, so
-	 * running out of space mid-run wastes the whole transfer. 2 GB is a floor, not an
-	 * estimate of the site size — it only catches an already-full disk up front.
-	 */
-	const CLI_MIN_FREE_DISK_BYTES = 2147483648;
-
-	/**
 	 * Verify an AJAX request: validates nonce and user capability.
 	 * Sends a JSON error response and exits if either check fails.
 	 *
@@ -2171,55 +2162,6 @@ include $file_path;';
 	}
 
 	/**
-	 * Requirements that have to hold before a local push is attempted.
-	 *
-	 * Checked up front so a missing dependency is reported as one clear message rather
-	 * than surfacing later as a raw error from whichever component happened to need it.
-	 *
-	 * Deliberately capability-based rather than platform-based: the command is not
-	 * restricted to any operating system, it just needs a compression extension, a
-	 * writable temp directory and a working database export.
-	 *
-	 * @return true|WP_Error
-	 */
-	public static function cli_local_push_preflight() {
-
-		$errors = array();
-
-		if ( ! class_exists( 'ZipArchive' ) && ! class_exists( 'PharData' ) ) {
-			$errors[] = esc_html__( 'Neither the ZipArchive nor the PharData PHP extension is available; one is required to build the backup.', 'instawp-connect' );
-		}
-
-		$temp_dir = get_temp_dir();
-
-		if ( empty( $temp_dir ) || ! is_dir( $temp_dir ) ) {
-			$errors[] = esc_html__( 'The PHP temporary directory could not be located.', 'instawp-connect' );
-		} elseif ( ! is_writable( $temp_dir ) ) {
-			/* translators: %s: temporary directory path. */
-			$errors[] = sprintf( esc_html__( 'The temporary directory is not writable: %s', 'instawp-connect' ), $temp_dir );
-		} else {
-			// The archive and the database dump are both written here before upload, so a
-			// full disk fails the migration halfway through rather than up front.
-			$free_space = @disk_free_space( $temp_dir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-
-			if ( false !== $free_space && $free_space < self::CLI_MIN_FREE_DISK_BYTES ) {
-				$errors[] = sprintf(
-					/* translators: 1: temporary directory path, 2: human readable free space. */
-					esc_html__( 'Not enough free space in the temporary directory %1$s (%2$s available). The backup is written there before it is uploaded.', 'instawp-connect' ),
-					$temp_dir,
-					size_format( $free_space )
-				);
-			}
-		}
-
-		if ( ! empty( $errors ) ) {
-			return new WP_Error( 'local_push_preflight_failed', implode( ' ', $errors ) );
-		}
-
-		return true;
-	}
-
-	/**
 	 * Export the database to a file in the temp directory.
 	 *
 	 * @return string|WP_Error Path to the dump, or WP_Error when the export failed.
@@ -2504,7 +2446,18 @@ include $file_path;';
 				}
 			}
 
-			$zip->close();
+			// ZipArchive writes the archive on close, so this is where a full disk, a
+			// permission problem or a corrupt entry actually surfaces. Ignoring the return
+			// value would hand back the path to a truncated archive as though it had been
+			// written successfully, and the migration would carry on and restore it.
+			if ( ! $zip->close() ) {
+				self::cli_delete_local_archives( array( $archive_path ) );
+
+				return new WP_Error(
+					'zip_close_failed',
+					esc_html__( 'The backup archive could not be written. Check the free space and permissions on the temporary directory.', 'instawp-connect' )
+				);
+			}
 
 			return $archive_path;
 		}

--- a/includes/class-instawp-tools.php
+++ b/includes/class-instawp-tools.php
@@ -2267,7 +2267,53 @@ include $file_path;';
 		);
 	}
 
-	public static function cli_archive_wordpress_files( $type = 'zip', $dirs_to_skip = array() ) {
+	/**
+	 * Directory names pruned from a local-push archive wherever they appear.
+	 *
+	 * Matched by name at any depth rather than by path, because these live under
+	 * whichever theme or plugin happens to have a build setup. Pruning the directory
+	 * stops the iterator descending into it at all, which is where the saving is: a
+	 * single node_modules can hold more files than the rest of the site combined, and
+	 * the cost lands three times over — walking, zipping and uploading.
+	 *
+	 * All of these are build, tooling or publishing metadata that WordPress never loads
+	 * at runtime. Applied to local push only, where the source is a developer machine
+	 * and they are near-certain to be present.
+	 *
+	 * Note this is a judgement call, not a rule: a theme or plugin that ships runtime
+	 * JavaScript inside node_modules would lose it. That is rare and the trade is worth
+	 * it here, but it is the reason this list is deliberately short and specific.
+	 *
+	 * `vendor` is intentionally NOT included — Composer dependencies are runtime code and
+	 * removing them breaks any plugin that ships one.
+	 *
+	 * @return array Directory names to prune.
+	 */
+	public static function get_local_push_excluded_dir_names() {
+		return array(
+			// Node build tooling.
+			'node_modules',
+			// Version control and CI metadata.
+			'.git',
+			'.github',
+			// WordPress.org listing assets: screenshots, banners, icons.
+			'.wordpress-org',
+		);
+	}
+
+	/**
+	 * Build an archive of the WordPress installation.
+	 *
+	 * @param string $type              Archive type, 'zip' or 'tgz'.
+	 * @param array  $dirs_to_skip      Relative paths to exclude.
+	 * @param array  $dir_names_to_skip Directory names pruned wherever they appear. Passed
+	 *                                  in rather than hardcoded so the policy belongs to
+	 *                                  the caller: what is safe to drop from a developer
+	 *                                  machine is not necessarily safe elsewhere.
+	 *
+	 * @return string|WP_Error Path to the archive.
+	 */
+	public static function cli_archive_wordpress_files( $type = 'zip', $dirs_to_skip = array(), $dir_names_to_skip = array() ) {
 
 		$archive_dir         = get_temp_dir();
 		$archive_name        = 'wordpress_backup_' . date( 'Y-m-d_H-i-s' );
@@ -2334,12 +2380,23 @@ include $file_path;';
 			// absolute filesystem paths).
 			$skip_basenames = array( 'error_log', 'debug.log' );
 
-			$filter_directory = function ( SplFileInfo $file, $key, RecursiveDirectoryIterator $iterator ) use ( $skip_folders, $skip_basenames, $normalize_path ) {
+			// Caller-supplied directory names. Rejecting a directory here stops the
+			// iterator descending into it, so the contents are never enumerated.
+			$skip_dir_names = array_filter( array_map( 'strval', (array) $dir_names_to_skip ) );
 
+			$filter_directory = function ( SplFileInfo $file, $key, RecursiveDirectoryIterator $iterator ) use ( $skip_folders, $skip_basenames, $skip_dir_names, $normalize_path ) {
+
+				$basename      = $file->getBasename();
 				$sub_path      = $normalize_path( $iterator->getSubPath() );
-				$relative_path = '' !== $sub_path ? $sub_path . '/' . $file->getBasename() : $file->getBasename();
+				$relative_path = '' !== $sub_path ? $sub_path . '/' . $basename : $basename;
 
-				if ( ! $file->isDir() && in_array( $file->getBasename(), $skip_basenames, true ) ) {
+				// Not restricted to directories: in a submodule or worktree checkout .git is
+				// a file rather than a directory, and it is no more wanted in either form.
+				if ( in_array( $basename, $skip_dir_names, true ) ) {
+					return false;
+				}
+
+				if ( ! $file->isDir() && in_array( $basename, $skip_basenames, true ) ) {
 					return false;
 				}
 

--- a/includes/sync/class-instawp-sync-apis.php
+++ b/includes/sync/class-instawp-sync-apis.php
@@ -136,68 +136,97 @@ class InstaWP_Sync_Apis extends InstaWP_Rest_Api {
 	public function download_media( WP_REST_Request $request ) {
 		// Defence in depth: validate again inside the callback so a future change to the
 		// route registration or to the permission callback cannot expose media files.
+		// Kept outside the try block so an authorization failure can never be swallowed.
 		$validated = $this->validate_sync_api_request( $request );
 		if ( is_wp_error( $validated ) ) {
 			// Returned as is, WordPress converts it into the proper HTTP error response.
 			return $validated;
 		}
 
-		// Get media_url from the request
-		$media_id = $request->get_param('media_id');
-		if ( empty( $media_id ) || ! is_numeric( $media_id ) || 1 > intval( $media_id ) ) {
-			return $this->send_response( array(
-				'success' => false,
-				'message' => __( 'Empty or invalid media id.', 'instawp-connect' ),
-			) );
-		}
+		// Everything from here up to the transfer only prepares the file, so a failure can
+		// still be reported as a normal response. The transfer itself stays outside.
+		try {
+			// Get media_url from the request
+			$media_id = $request->get_param('media_id');
+			if ( empty( $media_id ) || ! is_numeric( $media_id ) || 1 > intval( $media_id ) ) {
+				return $this->send_response( array(
+					'success' => false,
+					'message' => __( 'Empty or invalid media id.', 'instawp-connect' ),
+				) );
+			}
 
-		$media_id = intval( $media_id );
+			$media_id = intval( $media_id );
 
-		// Only real attachments may be served. get_attached_file() also resolves any other
-		// post type that happens to carry _wp_attached_file meta.
-		if ( 'attachment' !== get_post_type( $media_id ) ) {
+			// Only real attachments may be served. get_attached_file() also resolves any other
+			// post type that happens to carry _wp_attached_file meta.
+			if ( 'attachment' !== get_post_type( $media_id ) ) {
+				return $this->send_response( array(
+					'success' => false,
+					'message' => __( 'File not found.', 'instawp-connect' ),
+				) );
+			}
+
+			$file_path = get_attached_file( $media_id ); // Full path
+			if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
+				return $this->send_response( array(
+					'success' => false,
+					'message' => __( 'File not found.', 'instawp-connect' ),
+				) );
+			}
+
+			// Keep the served file inside the uploads directory. _wp_attached_file can hold an
+			// absolute path, so a tampered meta value could otherwise point anywhere on disk.
+			// The comparison stays lexical on purpose: resolving symlinks would break sites that
+			// symlink an uploads sub folder to shared media, and placing a symlink inside uploads
+			// already needs filesystem access, which makes this endpoint pointless to an attacker.
+			$upload_dir      = wp_get_upload_dir();
+			$upload_base_dir = empty( $upload_dir['basedir'] ) ? '' : wp_normalize_path( $upload_dir['basedir'] );
+			$normalized_path = wp_normalize_path( $file_path );
+
+			if ( empty( $upload_base_dir ) || false !== strpos( $normalized_path, '../' ) || 0 !== strpos( $normalized_path, trailingslashit( $upload_base_dir ) ) ) {
+				// Logged locally because the file does exist, the caller keeps the generic
+				// message so the response can not be used to probe which media ids exist.
+				Helper::add_error_log( array(
+					'title'   => 'instawp: sync download-media rejected a file outside the uploads directory',
+					'message' => $normalized_path,
+				) );
+
+				return $this->send_response( array(
+					'success' => false,
+					'message' => __( 'File not found.', 'instawp-connect' ),
+				) );
+			}
+
+			$file_type_ext = wp_check_filetype( $file_path );
+
+			if ( false === $file_type_ext['type'] || empty( $file_type_ext['ext'] ) || ! in_array( $file_type_ext['ext'], array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'mp4', 'pdf', 'doc', 'docx', 'xls', 'xlsx', 'csv', 'txt', 'rtf', 'html', 'zip', 'mp3', 'wma', 'mpg', 'flv', 'avi' ) ) ) {
+				return $this->send_response( array(
+					'success' => false,
+					'message' => __( 'File type not supported.', 'instawp-connect' ),
+				) );
+			}
+
+			// Discard anything already buffered (notices, BOM) so the file bytes stay intact.
+			// Bounded like wp_ob_end_flush_all(): a buffer that can not be removed, for example
+			// with zlib.output_compression on, keeps ob_get_level() unchanged and would otherwise
+			// spin until the request times out.
+			$ob_levels = ob_get_level();
+			for ( $i = 0; $i < $ob_levels; $i ++ ) {
+				if ( ! @ob_end_clean() ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+					break;
+				}
+			}
+		} catch ( \Throwable $th ) {
+			Helper::add_error_log( array( 'title' => 'instawp: sync download-media failed' ), $th );
+
 			return $this->send_response( array(
 				'success' => false,
 				'message' => __( 'File not found.', 'instawp-connect' ),
 			) );
 		}
 
-		$file_path = get_attached_file( $media_id ); // Full path
-		if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
-			return $this->send_response( array(
-				'success' => false,
-				'message' => __( 'File not found.', 'instawp-connect' ),
-			) );
-		}
-
-		// Keep the served file inside the uploads directory. _wp_attached_file can hold an
-		// absolute path, so a tampered meta value could otherwise point anywhere on disk.
-		$upload_dir      = wp_get_upload_dir();
-		$upload_base_dir = empty( $upload_dir['basedir'] ) ? '' : wp_normalize_path( $upload_dir['basedir'] );
-		$normalized_path = wp_normalize_path( $file_path );
-
-		if ( empty( $upload_base_dir ) || false !== strpos( $normalized_path, '../' ) || 0 !== strpos( $normalized_path, trailingslashit( $upload_base_dir ) ) ) {
-			return $this->send_response( array(
-				'success' => false,
-				'message' => __( 'File not found.', 'instawp-connect' ),
-			) );
-		}
-
-		$file_type_ext = wp_check_filetype( $file_path );
-
-		if ( false === $file_type_ext['type'] || empty( $file_type_ext['ext'] ) || ! in_array( $file_type_ext['ext'], array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'mp4', 'pdf', 'doc', 'docx', 'xls', 'xlsx', 'csv', 'txt', 'rtf', 'html', 'zip', 'mp3', 'wma', 'mpg', 'flv', 'avi' ) ) ) {
-			return $this->send_response( array(
-				'success' => false,
-				'message' => __( 'File type not supported.', 'instawp-connect' ),
-			) );
-		}
-
-		// Discard anything already buffered (notices, BOM) so the file bytes stay intact.
-		while ( ob_get_level() > 0 ) {
-			ob_end_clean();
-		}
-
-		// Serve the file for download
+		// Serve the file for download. Left outside the try block on purpose: once the headers
+		// and the first bytes are out there is nothing left to recover into a response.
 		header('Content-Description: File Transfer');
 		header('Content-Type: ' . $file_type_ext['type'] );
 		header('Content-Disposition: attachment; filename="' . basename( $file_path ) . '"');
@@ -205,7 +234,7 @@ class InstaWP_Sync_Apis extends InstaWP_Rest_Api {
 		header('Cache-Control: must-revalidate');
 		header('Pragma: public');
 		header('Content-Length: ' . filesize( $file_path ));
-	
+
 		readfile( $file_path );
 		exit;
 	}

--- a/includes/sync/class-instawp-sync-apis.php
+++ b/includes/sync/class-instawp-sync-apis.php
@@ -70,6 +70,25 @@ class InstaWP_Sync_Apis extends InstaWP_Rest_Api {
 	}
 
 	/**
+	 * Build an authorization WP_Error suitable for a permission callback.
+	 *
+	 * A permission callback must return true, false, null or a WP_Error. Any other
+	 * return value (a WP_REST_Response included) is treated as "authorized" by
+	 * WP_REST_Server, so every denial path has to hand back a real WP_Error with an
+	 * explicit HTTP status attached.
+	 *
+	 * @param string $message Error message to expose to the caller.
+	 * @param int    $status  Optional HTTP status code. Defaults to 401/403 based on login state.
+	 *
+	 * @return WP_Error
+	 */
+	private function sync_api_error( $message, $status = 0 ) {
+		$status = empty( $status ) ? rest_authorization_required_code() : intval( $status );
+
+		return new WP_Error( 'instawp_sync_rest_forbidden', $message, array( 'status' => $status ) );
+	}
+
+	/**
 	 * Valid api request and if invalid api key then stop executing.
 	 *
 	 * @param WP_REST_Request $request
@@ -79,24 +98,30 @@ class InstaWP_Sync_Apis extends InstaWP_Rest_Api {
 	public function validate_sync_api_request( WP_REST_Request $request ) {
 		// Get bearer token from the request
 		$bearer_token = $this->get_bearer_token( $request );
-		// Check if the bearer token is a wp error
+		// A missing or empty token must deny the request. The WP_Error has to be returned
+		// as is, wrapping it in a WP_REST_Response would authorize the request instead.
 		if ( is_wp_error( $bearer_token ) ) {
-			return $this->throw_error( $bearer_token );
+			return $this->sync_api_error( $bearer_token->get_error_message() );
 		}
 
 		$instawp_api_options = get_option( 'instawp_api_options' );
 
-		// check if the bearer token is empty
+		// Without connect details there is no shared secret to compare the token against.
 		if ( empty( $instawp_api_options ) || empty( $instawp_api_options['connect_id'] ) || empty( $instawp_api_options['connect_uuid'] ) ) {
-			return new WP_Error( 401, esc_html__( 'Empty API options.', 'instawp-connect' ) );
+			return $this->sync_api_error( esc_html__( 'Empty API options.', 'instawp-connect' ) );
 		}
 
 		// Prepare hash
 		$hash = hash( 'sha256', $instawp_api_options['connect_id'] . '_' . $instawp_api_options['connect_uuid'] );
 
-		if ( ! hash_equals( $bearer_token, $hash ) ) {
-			return new WP_Error( 401, esc_html__( 'Incorrect token.', 'instawp-connect' ) );
+		// Known value first, user supplied value second, as hash_equals() expects.
+		if ( ! hash_equals( $hash, $bearer_token ) ) {
+			return $this->sync_api_error( esc_html__( 'Incorrect token.', 'instawp-connect' ) );
 		}
+
+		// Note: the instawp_is_event_syncing toggle is intentionally NOT checked here. Media is
+		// requested by the peer site while it processes events, which can happen after the toggle
+		// has been switched off on this side, so gating on it would break legitimate syncs.
 
 		return true;
 	}
@@ -109,6 +134,14 @@ class InstaWP_Sync_Apis extends InstaWP_Rest_Api {
 	 * @return WP_REST_Response
 	 */
 	public function download_media( WP_REST_Request $request ) {
+		// Defence in depth: validate again inside the callback so a future change to the
+		// route registration or to the permission callback cannot expose media files.
+		$validated = $this->validate_sync_api_request( $request );
+		if ( is_wp_error( $validated ) ) {
+			// Returned as is, WordPress converts it into the proper HTTP error response.
+			return $validated;
+		}
+
 		// Get media_url from the request
 		$media_id = $request->get_param('media_id');
 		if ( empty( $media_id ) || ! is_numeric( $media_id ) || 1 > intval( $media_id ) ) {
@@ -117,10 +150,33 @@ class InstaWP_Sync_Apis extends InstaWP_Rest_Api {
 				'message' => __( 'Empty or invalid media id.', 'instawp-connect' ),
 			) );
 		}
-		
+
 		$media_id = intval( $media_id );
+
+		// Only real attachments may be served. get_attached_file() also resolves any other
+		// post type that happens to carry _wp_attached_file meta.
+		if ( 'attachment' !== get_post_type( $media_id ) ) {
+			return $this->send_response( array(
+				'success' => false,
+				'message' => __( 'File not found.', 'instawp-connect' ),
+			) );
+		}
+
 		$file_path = get_attached_file( $media_id ); // Full path
 		if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
+			return $this->send_response( array(
+				'success' => false,
+				'message' => __( 'File not found.', 'instawp-connect' ),
+			) );
+		}
+
+		// Keep the served file inside the uploads directory. _wp_attached_file can hold an
+		// absolute path, so a tampered meta value could otherwise point anywhere on disk.
+		$upload_dir      = wp_get_upload_dir();
+		$upload_base_dir = empty( $upload_dir['basedir'] ) ? '' : wp_normalize_path( $upload_dir['basedir'] );
+		$normalized_path = wp_normalize_path( $file_path );
+
+		if ( empty( $upload_base_dir ) || false !== strpos( $normalized_path, '../' ) || 0 !== strpos( $normalized_path, trailingslashit( $upload_base_dir ) ) ) {
 			return $this->send_response( array(
 				'success' => false,
 				'message' => __( 'File not found.', 'instawp-connect' ),
@@ -134,6 +190,11 @@ class InstaWP_Sync_Apis extends InstaWP_Rest_Api {
 				'success' => false,
 				'message' => __( 'File type not supported.', 'instawp-connect' ),
 			) );
+		}
+
+		// Discard anything already buffered (notices, BOM) so the file bytes stay intact.
+		while ( ob_get_level() > 0 ) {
+			ob_end_clean();
 		}
 
 		// Serve the file for download

--- a/includes/sync/class-instawp-sync-apis.php
+++ b/includes/sync/class-instawp-sync-apis.php
@@ -143,8 +143,9 @@ class InstaWP_Sync_Apis extends InstaWP_Rest_Api {
 			return $validated;
 		}
 
-		// Everything from here up to the transfer only prepares the file, so a failure can
-		// still be reported as a normal response. The transfer itself stays outside.
+		// Preparing the file and serving it both run under the guard below. A failure while
+		// preparing still becomes a normal response, a failure once the transfer started can
+		// only end the request, which is what the headers_sent() check in the catch does.
 		try {
 			// Get media_url from the request
 			$media_id = $request->get_param('media_id');

--- a/includes/sync/class-instawp-sync-apis.php
+++ b/includes/sync/class-instawp-sync-apis.php
@@ -216,27 +216,33 @@ class InstaWP_Sync_Apis extends InstaWP_Rest_Api {
 					break;
 				}
 			}
+
+			// Serve the file for download
+			header('Content-Description: File Transfer');
+			header('Content-Type: ' . $file_type_ext['type'] );
+			header('Content-Disposition: attachment; filename="' . basename( $file_path ) . '"');
+			header('Expires: 0');
+			header('Cache-Control: must-revalidate');
+			header('Pragma: public');
+			header('Content-Length: ' . filesize( $file_path ));
+
+			readfile( $file_path );
+			exit;
 		} catch ( \Throwable $th ) {
 			Helper::add_error_log( array( 'title' => 'instawp: sync download-media failed' ), $th );
+
+			// If the transfer already started, the headers and part of the body are out and the
+			// peer is reading binary. Appending a JSON error would only corrupt what it receives,
+			// so the request is ended instead and the peer sees a truncated download.
+			if ( headers_sent() ) {
+				exit;
+			}
 
 			return $this->send_response( array(
 				'success' => false,
 				'message' => __( 'File not found.', 'instawp-connect' ),
 			) );
 		}
-
-		// Serve the file for download. Left outside the try block on purpose: once the headers
-		// and the first bytes are out there is nothing left to recover into a response.
-		header('Content-Description: File Transfer');
-		header('Content-Type: ' . $file_type_ext['type'] );
-		header('Content-Disposition: attachment; filename="' . basename( $file_path ) . '"');
-		header('Expires: 0');
-		header('Cache-Control: must-revalidate');
-		header('Pragma: public');
-		header('Content-Length: ' . filesize( $file_path ));
-
-		readfile( $file_path );
-		exit;
 	}
 
 	/**

--- a/instawp-connect.php
+++ b/instawp-connect.php
@@ -8,7 +8,7 @@
  * @wordpress-plugin
  * Plugin Name:       InstaWP Connect
  * Description:       1-click WordPress plugin for Staging, Migrations, Management, Sync and Companion plugin for InstaWP.
- * Version:           0.1.3.8
+ * Version:           0.1.3.9
  * Author:            InstaWP Team
  * Author URI:        https://instawp.com/
  * License:           GPL-3.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 global $wpdb;
 
-defined( 'INSTAWP_PLUGIN_VERSION' ) || define( 'INSTAWP_PLUGIN_VERSION', '0.1.3.8' );
+defined( 'INSTAWP_PLUGIN_VERSION' ) || define( 'INSTAWP_PLUGIN_VERSION', '0.1.3.9' );
 defined( 'INSTAWP_API_DOMAIN_PROD' ) || define( 'INSTAWP_API_DOMAIN_PROD', 'https://app.instawp.io' );
 
 defined( 'INSTAWP_PLUGIN_URL' ) || define( 'INSTAWP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/instawp-connect.php
+++ b/instawp-connect.php
@@ -8,7 +8,7 @@
  * @wordpress-plugin
  * Plugin Name:       InstaWP Connect
  * Description:       1-click WordPress plugin for Staging, Migrations, Management, Sync and Companion plugin for InstaWP.
- * Version:           0.1.3.7
+ * Version:           0.1.3.8
  * Author:            InstaWP Team
  * Author URI:        https://instawp.com/
  * License:           GPL-3.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 global $wpdb;
 
-defined( 'INSTAWP_PLUGIN_VERSION' ) || define( 'INSTAWP_PLUGIN_VERSION', '0.1.3.7' );
+defined( 'INSTAWP_PLUGIN_VERSION' ) || define( 'INSTAWP_PLUGIN_VERSION', '0.1.3.8' );
 defined( 'INSTAWP_API_DOMAIN_PROD' ) || define( 'INSTAWP_API_DOMAIN_PROD', 'https://app.instawp.io' );
 
 defined( 'INSTAWP_PLUGIN_URL' ) || define( 'INSTAWP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/instawp-connect.php
+++ b/instawp-connect.php
@@ -8,7 +8,7 @@
  * @wordpress-plugin
  * Plugin Name:       InstaWP Connect
  * Description:       1-click WordPress plugin for Staging, Migrations, Management, Sync and Companion plugin for InstaWP.
- * Version:           0.1.3.9
+ * Version:           0.1.3.8
  * Author:            InstaWP Team
  * Author URI:        https://instawp.com/
  * License:           GPL-3.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 global $wpdb;
 
-defined( 'INSTAWP_PLUGIN_VERSION' ) || define( 'INSTAWP_PLUGIN_VERSION', '0.1.3.9' );
+defined( 'INSTAWP_PLUGIN_VERSION' ) || define( 'INSTAWP_PLUGIN_VERSION', '0.1.3.8' );
 defined( 'INSTAWP_API_DOMAIN_PROD' ) || define( 'INSTAWP_API_DOMAIN_PROD', 'https://app.instawp.io' );
 
 defined( 'INSTAWP_PLUGIN_URL' ) || define( 'INSTAWP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 - Improved: Local push reports progress and site size, and reports backup failures more clearly.
 - Fixed: Local push from Windows now transfers files correctly.
 - Security: Hardened cleanup of temporary migration files.
+- Security: Hardened authentication and file handling for two-way sync media transfers.
 
 = 0.1.3.7 - 03 August 2026 =
 - Security: Hardened the handling and cleanup of temporary migration files.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: clone, migrate, staging, backup, restore
 Requires at least: 5.6
 Tested up to: 7.0
 Requires PHP: 7.0
-Stable tag: 0.1.3.9
+Stable tag: 0.1.3.8
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 
@@ -98,15 +98,13 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
-= 0.1.3.9 - 04 August 2026 =
-- Fixed: Local push migration reported no progress and no site size in the dashboard, so a migration appeared never to start and finished without ever showing what was transferred.
-- Improved: Local push now checks its requirements before starting and reports exactly what is missing, instead of failing part way through with an unclear error.
-- Improved: A failed database export during local push is now reported with the underlying reason rather than an unrelated error.
-
 = 0.1.3.8 - 04 August 2026 =
 - Fixed: Local push migration copied the source site's .htaccess, wp-config.php, caches and log files to the destination, which could leave the migrated site redirecting to the original domain.
 - Security: Local push migration now removes the transferred backup and database files from the destination site and the local machine once the migration completes.
 - Fixed: Local push migration from Windows stored files in the backup using their full local path, which produced an empty site on the destination.
+- Fixed: Local push migration reported no progress and no site size in the dashboard, so a migration appeared never to start and finished without ever showing what was transferred.
+- Improved: Local push now checks its requirements before starting and reports exactly what is missing, instead of failing part way through with an unclear error.
+- Improved: A failed database export during local push is now reported with the underlying reason rather than an unrelated error.
 
 = 0.1.3.7 - 03 August 2026 =
 - Security: Hardened the handling and cleanup of temporary migration files.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: clone, migrate, staging, backup, restore
 Requires at least: 5.6
 Tested up to: 7.0
 Requires PHP: 7.0
-Stable tag: 0.1.3.7
+Stable tag: 0.1.3.8
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 
@@ -97,6 +97,11 @@ Need support or want to partner with us? Go to our [website](http://instawp.com/
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team helps validate, triage, and handle any security vulnerabilities. [Report a security vulnerability](https://patchstack.com/database/vdp/instawp-connect).
 
 == Changelog ==
+
+= 0.1.3.8 - 04 August 2026 =
+- Fixed: Local push migration copied the source site's .htaccess, wp-config.php, caches and log files to the destination, which could leave the migrated site redirecting to the original domain.
+- Security: Local push migration now removes the transferred backup and database files from the destination site and the local machine once the migration completes.
+- Fixed: Local push migration from Windows stored files in the backup using their full local path, which produced an empty site on the destination.
 
 = 0.1.3.7 - 03 August 2026 =
 - Security: Hardened the handling and cleanup of temporary migration files.

--- a/readme.txt
+++ b/readme.txt
@@ -98,13 +98,11 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
-= 0.1.3.8 - 05 August 2026 =
-- Fixed: Local push copied the source site's .htaccess, wp-config.php, caches and log files, which could leave the migrated site redirecting to the original domain.
-- Fixed: Local push from Windows produced an empty destination site.
-- Fixed: Local push now reports progress and site size in the dashboard.
-- Security: Local push removes the transferred backup and database files from both the destination and the local machine.
-- Improved: Local push skips build and version control folders (node_modules, .git, .github, .wordpress-org) for faster transfers.
-- Improved: Local push checks its requirements before starting and reports database export failures clearly.
+= 0.1.3.8 - Beta =
+- Improved: Local push no longer copies host-specific configuration, caches, logs, or build and version control folders to the destination.
+- Improved: Local push reports progress and site size, checks its requirements before starting, and reports failures more clearly.
+- Fixed: Local push from Windows now transfers files correctly.
+- Security: Hardened cleanup of temporary migration files.
 
 = 0.1.3.7 - 03 August 2026 =
 - Security: Hardened the handling and cleanup of temporary migration files.

--- a/readme.txt
+++ b/readme.txt
@@ -98,7 +98,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
-= 0.1.3.8 - Beta =
+= 0.1.3.8 - 12 August 2026 =
 - Improved: Local push no longer copies host-specific configuration, caches, logs, or build and version control folders to the destination.
 - Improved: Local push reports progress and site size, and reports backup failures more clearly.
 - Fixed: Local push from Windows now transfers files correctly.

--- a/readme.txt
+++ b/readme.txt
@@ -98,13 +98,13 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
-= 0.1.3.8 - 04 August 2026 =
-- Fixed: Local push migration copied the source site's .htaccess, wp-config.php, caches and log files to the destination, which could leave the migrated site redirecting to the original domain.
-- Security: Local push migration now removes the transferred backup and database files from the destination site and the local machine once the migration completes.
-- Fixed: Local push migration from Windows stored files in the backup using their full local path, which produced an empty site on the destination.
-- Fixed: Local push migration reported no progress and no site size in the dashboard, so a migration appeared never to start and finished without ever showing what was transferred.
-- Improved: Local push now checks its requirements before starting and reports exactly what is missing, instead of failing part way through with an unclear error.
-- Improved: A failed database export during local push is now reported with the underlying reason rather than an unrelated error.
+= 0.1.3.8 - 05 August 2026 =
+- Fixed: Local push copied the source site's .htaccess, wp-config.php, caches and log files, which could leave the migrated site redirecting to the original domain.
+- Fixed: Local push from Windows produced an empty destination site.
+- Fixed: Local push now reports progress and site size in the dashboard.
+- Security: Local push removes the transferred backup and database files from both the destination and the local machine.
+- Improved: Local push skips build and version control folders (node_modules, .git, .github, .wordpress-org) for faster transfers.
+- Improved: Local push checks its requirements before starting and reports database export failures clearly.
 
 = 0.1.3.7 - 03 August 2026 =
 - Security: Hardened the handling and cleanup of temporary migration files.

--- a/readme.txt
+++ b/readme.txt
@@ -100,7 +100,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 = 0.1.3.8 - Beta =
 - Improved: Local push no longer copies host-specific configuration, caches, logs, or build and version control folders to the destination.
-- Improved: Local push reports progress and site size, checks its requirements before starting, and reports failures more clearly.
+- Improved: Local push reports progress and site size, and reports backup failures more clearly.
 - Fixed: Local push from Windows now transfers files correctly.
 - Security: Hardened cleanup of temporary migration files.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: clone, migrate, staging, backup, restore
 Requires at least: 5.6
 Tested up to: 7.0
 Requires PHP: 7.0
-Stable tag: 0.1.3.8
+Stable tag: 0.1.3.9
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 
@@ -97,6 +97,11 @@ Need support or want to partner with us? Go to our [website](http://instawp.com/
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team helps validate, triage, and handle any security vulnerabilities. [Report a security vulnerability](https://patchstack.com/database/vdp/instawp-connect).
 
 == Changelog ==
+
+= 0.1.3.9 - 04 August 2026 =
+- Fixed: Local push migration reported no progress and no site size in the dashboard, so a migration appeared never to start and finished without ever showing what was transferred.
+- Improved: Local push now checks its requirements before starting and reports exactly what is missing, instead of failing part way through with an unclear error.
+- Improved: A failed database export during local push is now reported with the underlying reason rather than an unrelated error.
 
 = 0.1.3.8 - 04 August 2026 =
 - Fixed: Local push migration copied the source site's .htaccess, wp-config.php, caches and log files to the destination, which could leave the migrated site redirecting to the original domain.


### PR DESCRIPTION

- Improved: Local push no longer copies host-specific configuration, caches, logs, or build and version control folders to the destination.
- Improved: Local push reports progress and site size, and reports backup failures more clearly.
- Fixed: Local push from Windows now transfers files correctly.
- Security: Hardened cleanup of temporary migration files.
- Security: Hardened authentication and file handling for two-way sync media transfers.